### PR TITLE
feat(codex): 支持 agent model_catalog_json 并让 model 覆盖全局配置

### DIFF
--- a/lib/agents/config_loader_runtime/common.py
+++ b/lib/agents/config_loader_runtime/common.py
@@ -58,6 +58,7 @@ ALLOWED_AGENT_KEYS = {
     'permission',
     'queue_policy',
     'model',
+    'model_catalog_json',
     'thinking',
     'key',
     'url',

--- a/lib/agents/config_loader_runtime/defaults_runtime/rendering_runtime/serialization.py
+++ b/lib/agents/config_loader_runtime/defaults_runtime/rendering_runtime/serialization.py
@@ -39,6 +39,9 @@ def update_optional_agent_fields(payload: dict[str, object], spec) -> None:
         payload['provider_command_template'] = spec.provider_command_template
     if spec.model is not None:
         payload['model'] = spec.model
+    model_catalog_json = spec.provider_profile.env.get('model_catalog_json')
+    if model_catalog_json is not None:
+        payload['model_catalog_json'] = model_catalog_json
     if spec.thinking is not None:
         payload['thinking'] = spec.thinking
     startup_args = _config_startup_args(spec)
@@ -99,6 +102,7 @@ def _provider_profile_config_dict(spec) -> dict[str, object] | None:
         key: value
         for key, value in profile.env.items()
         if key not in provider_api_env_keys(spec.provider)
+        and not (spec.provider == 'codex' and key == 'model_catalog_json')
     }
     payload: dict[str, object] = {}
     if profile.mode != default_profile.mode:

--- a/lib/agents/config_loader_runtime/parsing_runtime/agent_specs.py
+++ b/lib/agents/config_loader_runtime/parsing_runtime/agent_specs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from agents.models import (
@@ -40,6 +41,26 @@ def build_agent_spec(agent_name: str, raw: dict[str, Any]) -> AgentSpec:
         if raw.get('provider_profile') is not None
         else ProviderProfileSpec()
     )
+    if raw.get('model_catalog_json') is not None:
+        if provider != 'codex':
+            raise ConfigValidationError(
+                f'agents.{agent_name}.model_catalog_json is supported only for codex'
+            )
+        model_catalog_json = expect_string(
+            raw['model_catalog_json'],
+            field_name=f'agents.{agent_name}.model_catalog_json',
+        )
+        configured_catalog = provider_profile.env.get('model_catalog_json')
+        if configured_catalog is not None and configured_catalog != model_catalog_json:
+            raise ConfigValidationError(
+                f'agents.{agent_name}.model_catalog_json conflicts with '
+                f'agents.{agent_name}.provider_profile.env.model_catalog_json'
+            )
+        if configured_catalog is None:
+            provider_profile = replace(
+                provider_profile,
+                env={**provider_profile.env, 'model_catalog_json': model_catalog_json},
+            )
     _validate_provider_profile_runtime_home(agent_name, provider=provider, provider_profile=provider_profile)
     if api != AgentApiSpec():
         provider_profile = _apply_agent_api_shortcut(

--- a/lib/cli/services/provider_hooks.py
+++ b/lib/cli/services/provider_hooks.py
@@ -254,6 +254,11 @@ def _materialize_provider_home(
             command_policy=command_policy,
             memory_projection_event_path=layout.agent_events_path(spec.name),
             memory_projection_marker_path=Path(runtime_dir) / 'codex-memory-projection.json',
+            # The cached resolved profile can predate a ccb.config edit, so the
+            # agent's current model/catalog are plumbed from the live spec rather
+            # than read out of the possibly-stale profile env.
+            model=spec.model,
+            model_catalog_json=spec.provider_profile.env.get('model_catalog_json'),
         )
         return
     if provider == 'droid':

--- a/lib/provider_backends/codex/launcher_runtime/command_runtime/service.py
+++ b/lib/provider_backends/codex/launcher_runtime/command_runtime/service.py
@@ -191,6 +191,7 @@ def _env_map(runtime_dir: Path, launch_session_id: str, *, spec, profile, codex_
     if profile is not None:
         explicit_env.update(profile.env)
     explicit_env.update(spec.env)
+    explicit_env.pop('model_catalog_json', None)
     if codex_api_authority(profile) is not None:
         explicit_env.pop('OPENAI_BASE_URL', None)
         explicit_env.pop('OPENAI_API_BASE', None)

--- a/lib/provider_profiles/codex_home_config.py
+++ b/lib/provider_profiles/codex_home_config.py
@@ -58,6 +58,7 @@ _CODEX_AUTH_SIDECAR_FILENAMES = (
     'company-codex-api-key',
     'company-codex.config.toml',
 )
+_CODEX_MODEL_CATALOG_JSON_KEY = 'model_catalog_json'
 _CODEX_AUTH_SIDECAR_REF_RE = re.compile(
     r'(?:'
     r'\$\{CODEX_HOME(?::-[^}]*)?\}'
@@ -135,6 +136,8 @@ def materialize_codex_home_config(
     command_policy=None,
     memory_projection_event_path: Path | None = None,
     memory_projection_marker_path: Path | None = None,
+    model: str | None = None,
+    model_catalog_json: str | None = None,
 ) -> Path:
     target_home = Path(target_home).expanduser()
     source_home = Path(source_home).expanduser() if source_home is not None else _system_codex_home()
@@ -195,6 +198,27 @@ def materialize_codex_home_config(
         agent_name=agent_name,
         runtime_dir=runtime_dir,
     )
+    configured_model_catalog = (
+        model_catalog_json
+        if model_catalog_json is not None
+        else _profile_env(profile).get(_CODEX_MODEL_CATALOG_JSON_KEY)
+    )
+    model_catalog_name = _codex_model_catalog_sidecar_name(
+        configured_model_catalog or _read_source_config_payload(target_config).get(_CODEX_MODEL_CATALOG_JSON_KEY)
+    )
+    if configured_model_catalog and model_catalog_name is None:
+        raise RuntimeError(
+            f'Codex {_CODEX_MODEL_CATALOG_JSON_KEY} must reference a safe .json file name'
+        )
+    if model_catalog_name is not None:
+        _set_codex_model_catalog_json(target_config, model_catalog_name)
+        _materialize_config_sidecars(
+            source_home,
+            target_home,
+            required_names=(model_catalog_name,),
+        )
+    if model is not None:
+        _set_codex_model(target_config, model)
 
     previous_auth_projection = _read_auth_projection_manifest(target_home)
     _materialize_auth_file(
@@ -1163,6 +1187,70 @@ def _codex_auth_sidecar_names(source_home: Path, source_config: Path) -> set[str
         if _is_safe_codex_auth_sidecar_name(name):
             names.add(name)
     return names
+
+
+def _materialize_config_sidecars(
+    source_home: Path,
+    target_home: Path,
+    *,
+    required_names: tuple[str, ...],
+) -> None:
+    for name in sorted(set(required_names)):
+        source = Path(source_home).expanduser() / name
+        target = Path(target_home).expanduser() / name
+        if _probe_regular_source_file(source):
+            try:
+                copied = copy_regular_file(source, target)
+            except OSError as exc:
+                raise RuntimeError(
+                    f'cannot copy inherited Codex config sidecar: {source}: {exc}'
+                ) from exc
+            if not copied:
+                raise RuntimeError(f'cannot copy inherited Codex config sidecar: {source}')
+        if not target.is_file():
+            raise RuntimeError(
+                f'Codex model catalog file is missing: {source} '
+                f'(expected managed file: {target})'
+            )
+
+
+def _set_codex_model_catalog_json(target_config: Path, name: str) -> None:
+    payload = _read_source_config_payload(target_config)
+    payload[_CODEX_MODEL_CATALOG_JSON_KEY] = name
+    target_config.write_text(_render_toml_document(payload), encoding='utf-8')
+
+
+def _set_codex_model(target_config: Path, model: str) -> None:
+    normalized = str(model or '').strip()
+    if not normalized:
+        return
+    payload = _read_source_config_payload(target_config)
+    payload['model'] = normalized
+    target_config.write_text(_render_toml_document(payload), encoding='utf-8')
+
+
+def _codex_model_catalog_sidecar_name(value: object) -> str | None:
+    raw = str(value or '').strip() if isinstance(value, str) else ''
+    if not raw:
+        return None
+    normalized = raw.replace('\\', '/')
+    if '/' in normalized:
+        match = _CODEX_AUTH_SIDECAR_REF_RE.fullmatch(normalized)
+        if not match:
+            return None
+        raw = str(match.group('name') or '').strip()
+    if _is_safe_codex_model_catalog_sidecar_name(raw):
+        return raw
+    return None
+
+
+def _is_safe_codex_model_catalog_sidecar_name(name: str) -> bool:
+    if not name or '/' in name or '\\' in name or name in {'.', '..'} or name.startswith('.'):
+        return False
+    lower = name.lower()
+    if lower in {'auth.json', 'config.toml'}:
+        return False
+    return lower.endswith('.json')
 
 
 def _is_safe_codex_auth_sidecar_name(name: str) -> bool:

--- a/lib/provider_profiles/materializer.py
+++ b/lib/provider_profiles/materializer.py
@@ -219,6 +219,8 @@ def _materialize_codex_profile(
             shared_cache_root=layout.shared_cache_dir,
             memory_projection_event_path=layout.agent_events_path(spec.name),
             memory_projection_marker_path=runtime_dir / 'codex-memory-projection.json',
+            model=spec.model,
+            model_catalog_json=profile_spec.env.get('model_catalog_json'),
         )
 
     return ResolvedProviderProfile(

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -33,13 +33,16 @@ from provider_backends.qwen.home import materialize_qwen_home_config
 import provider_core.projected_assets as projected_assets
 import provider_core.projected_settings as projected_settings
 import provider_profiles.codex_home_config as codex_home_config
-from provider_profiles.codex_home_config import codex_provider_authority_fingerprint
+from provider_profiles.codex_home_config import (
+    codex_provider_authority_fingerprint,
+    materialize_codex_home_config,
+)
 from provider_profiles import materialize_provider_profile, validate_provider_runtime_home_uniqueness
 from provider_core.pathing import session_filename_for_agent
 from storage.paths import PathLayout
 
 
-def _spec(name: str, provider: str = "codex", *, provider_profile: ProviderProfileSpec | None = None) -> AgentSpec:
+def _spec(name: str, provider: str = "codex", *, provider_profile: ProviderProfileSpec | None = None, model: str | None = None) -> AgentSpec:
     return AgentSpec(
         name=name,
         provider=provider,
@@ -51,6 +54,7 @@ def _spec(name: str, provider: str = "codex", *, provider_profile: ProviderProfi
         permission_default=PermissionMode.MANUAL,
         queue_policy=QueuePolicy.SERIAL_PER_AGENT,
         provider_profile=provider_profile or ProviderProfileSpec(),
+        model=model,
     )
 
 
@@ -1725,6 +1729,7 @@ def test_materialize_codex_profile_writes_agent_local_provider_config_for_explic
             [
                 'model_provider = "stale"',
                 'model = "gpt-5.4-openai-compact"',
+                'model_catalog_json = "model.json"',
                 'model_reasoning_effort = "xhigh"',
                 'disable_response_storage = true',
                 '',
@@ -1741,6 +1746,7 @@ def test_materialize_codex_profile_writes_agent_local_provider_config_for_explic
         ),
         encoding='utf-8',
     )
+    (source_home / 'model.json').write_text('{"deepseek-v4-flash":{"context_window":128000}}\n', encoding='utf-8')
     monkeypatch.setenv('CODEX_HOME', str(source_home))
     _write_codex_plugin_source(
         source_home,
@@ -1771,6 +1777,7 @@ def test_materialize_codex_profile_writes_agent_local_provider_config_for_explic
     config_text = (runtime_home / 'config.toml').read_text(encoding='utf-8')
     assert 'model_provider = "custom"' in config_text
     assert 'model = "gpt-5.4-openai-compact"' in config_text
+    assert 'model_catalog_json = "model.json"' in config_text
     assert 'model_reasoning_effort = "xhigh"' in config_text
     assert 'disable_response_storage = true' in config_text
     assert '[projects."/tmp/demo-project"]' in config_text
@@ -1789,9 +1796,185 @@ def test_materialize_codex_profile_writes_agent_local_provider_config_for_explic
     auth_manifest = json.loads((runtime_home / '.ccb-auth-projection.json').read_text(encoding='utf-8'))
     assert auth_manifest['status'] == 'explicit_api_authority'
     assert auth_manifest['projected_sidecars'] == []
+    assert (runtime_home / 'model.json').read_text(encoding='utf-8') == '{"deepseek-v4-flash":{"context_window":128000}}\n'
     assert (runtime_home / '.tmp' / 'plugins.sha').read_text(encoding='utf-8') == 'plugins-sha-v1\n'
     assert (runtime_home / '.tmp' / 'plugins' / '.agents' / 'plugins' / 'marketplace.json').is_file()
     assert (runtime_home / '.tmp' / 'plugins' / 'plugins' / 'weatherpromise' / 'skills' / 'weatherpromise' / 'SKILL.md').read_text(encoding='utf-8') == 'plugin skill explicit\n'
+
+
+def test_materialize_codex_profile_projects_explicit_model_catalog_without_api_base(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text('model = "deepseek-v4-flash"\n', encoding='utf-8')
+    (source_home / 'model.json').write_text('{"deepseek-v4-flash":{"context_window":128000}}\n', encoding='utf-8')
+
+    profile = ProviderProfileSpec(
+        mode='isolated',
+        env={'model_catalog_json': 'model.json'},
+    )
+
+    runtime_home = tmp_path / 'managed-home'
+    materialize_codex_home_config(
+        runtime_home,
+        profile=profile,
+        source_home=source_home,
+        project_root=project_root,
+    )
+
+    config = tomllib.loads((runtime_home / 'config.toml').read_text(encoding='utf-8'))
+    assert config['model_catalog_json'] == 'model.json'
+    assert (runtime_home / 'model.json').read_text(encoding='utf-8') == (
+        '{"deepseek-v4-flash":{"context_window":128000}}\n'
+    )
+
+
+def test_materialize_codex_profile_requires_model_catalog_file_in_managed_home(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text('model = "deepseek-v4-flash"\n', encoding='utf-8')
+    runtime_home = tmp_path / 'managed-home'
+    runtime_home.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(RuntimeError, match='Codex model catalog file is missing'):
+        materialize_codex_home_config(
+            runtime_home,
+            profile=ProviderProfileSpec(
+                mode='isolated',
+                env={'model_catalog_json': 'model.json'},
+            ),
+            source_home=source_home,
+            project_root=project_root,
+        )
+
+
+def test_materialize_codex_profile_accepts_existing_managed_model_catalog_file(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text('model = "deepseek-v4-flash"\n', encoding='utf-8')
+    runtime_home = tmp_path / 'managed-home'
+    runtime_home.mkdir(parents=True, exist_ok=True)
+    (runtime_home / 'model.json').write_text('{"deepseek-v4-flash":{"source":"managed"}}\n', encoding='utf-8')
+
+    materialize_codex_home_config(
+        runtime_home,
+        profile=ProviderProfileSpec(
+            mode='isolated',
+            env={'model_catalog_json': 'model.json'},
+        ),
+        source_home=source_home,
+        project_root=project_root,
+    )
+
+    config = tomllib.loads((runtime_home / 'config.toml').read_text(encoding='utf-8'))
+    assert config['model_catalog_json'] == 'model.json'
+    assert (runtime_home / 'model.json').read_text(encoding='utf-8') == (
+        '{"deepseek-v4-flash":{"source":"managed"}}\n'
+    )
+
+
+def test_materialize_codex_home_config_agent_model_overrides_inherited_global_model(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text('model = "gpt-global"\n', encoding='utf-8')
+
+    # Without an explicit agent model, the inherited global model is preserved.
+    plain_home = tmp_path / 'managed-plain'
+    materialize_codex_home_config(
+        plain_home,
+        profile=ProviderProfileSpec(),
+        source_home=source_home,
+        project_root=project_root,
+    )
+    assert tomllib.loads((plain_home / 'config.toml').read_text(encoding='utf-8'))['model'] == 'gpt-global'
+
+    # The agent's model field overrides the inherited global model.
+    agent_home = tmp_path / 'managed-agent'
+    materialize_codex_home_config(
+        agent_home,
+        profile=ProviderProfileSpec(),
+        source_home=source_home,
+        project_root=project_root,
+        model='deepseek-v4-pro',
+    )
+    config = tomllib.loads((agent_home / 'config.toml').read_text(encoding='utf-8'))
+    assert config['model'] == 'deepseek-v4-pro'
+
+
+def test_materialize_codex_home_config_explicit_model_catalog_wins_over_stale_profile_env(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text('model = "deepseek-v4-flash"\n', encoding='utf-8')
+    (source_home / 'models.json').write_text('{"deepseek-v4-pro":{"context_window":128000}}\n', encoding='utf-8')
+    runtime_home = tmp_path / 'managed-home'
+
+    # The resolved profile env is stale and does not carry model_catalog_json;
+    # the explicit argument (plumbed from the live spec) must still project it.
+    materialize_codex_home_config(
+        runtime_home,
+        profile=ProviderProfileSpec(
+            mode='isolated',
+            env={'OPENAI_BASE_URL': 'https://aspai.example/v1'},
+        ),
+        source_home=source_home,
+        project_root=project_root,
+        model_catalog_json='models.json',
+    )
+
+    config = tomllib.loads((runtime_home / 'config.toml').read_text(encoding='utf-8'))
+    assert config['model_catalog_json'] == 'models.json'
+    assert (runtime_home / 'models.json').read_text(encoding='utf-8') == (
+        '{"deepseek-v4-pro":{"context_window":128000}}\n'
+    )
+
+
+def test_materialize_codex_profile_writes_agent_model_and_catalog_over_inherited_global(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    source_home = tmp_path / 'system-codex-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text(
+        'model = "gpt-global"\nmodel_reasoning_effort = "high"\n',
+        encoding='utf-8',
+    )
+    (source_home / 'models.json').write_text('{"deepseek-v4-pro":{"context_window":128000}}\n', encoding='utf-8')
+    monkeypatch.setenv('CODEX_HOME', str(source_home))
+
+    profile = materialize_provider_profile(
+        layout=PathLayout(project_root),
+        spec=_spec(
+            'agent1',
+            provider_profile=ProviderProfileSpec(
+                mode='isolated',
+                env={
+                    'OPENAI_BASE_URL': 'https://aspai.example/v1',
+                    'model_catalog_json': 'models.json',
+                },
+            ),
+            model='deepseek-v4-pro',
+        ),
+        workspace_path=project_root,
+    )
+
+    runtime_home = Path(profile.runtime_home or '')
+    config = tomllib.loads((runtime_home / 'config.toml').read_text(encoding='utf-8'))
+    assert config['model'] == 'deepseek-v4-pro'
+    assert config['model_catalog_json'] == 'models.json'
+    assert (runtime_home / 'models.json').read_text(encoding='utf-8') == (
+        '{"deepseek-v4-pro":{"context_window":128000}}\n'
+    )
 
 
 def test_materialize_codex_profile_refreshes_plugin_projection_when_source_changes(tmp_path: Path, monkeypatch) -> None:

--- a/test/test_v2_config_loader.py
+++ b/test/test_v2_config_loader.py
@@ -742,6 +742,36 @@ exclude = ["trellis-meta"]
     assert overlay.exclude == ('trellis-meta',)
 
 
+@pytest.mark.parametrize('location', ['agent', 'provider_profile_env'])
+def test_load_project_config_supports_codex_model_catalog_json(tmp_path: Path, location: str) -> None:
+    project_root = tmp_path / f'repo-{location}'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    extra = (
+        'model_catalog_json = "model.json"\n'
+        if location == 'agent'
+        else '[agents.agent1.provider_profile.env]\nmodel_catalog_json = "model.json"\n'
+    )
+    _write(
+        config_path,
+        f"""version = 2
+default_agents = ["agent1"]
+layout = "cmd; agent1"
+cmd_enabled = true
+
+[agents.agent1]
+provider = "codex"
+target = "."
+workspace_mode = "git-worktree"
+restore = "auto"
+permission = "manual"
+{extra}""",
+    )
+
+    spec = load_project_config(project_root).config.agents['agent1']
+
+    assert spec.provider_profile.env['model_catalog_json'] == 'model.json'
+
+
 def test_load_project_config_supports_workspace_path_and_group_fields(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo'
     config_path = project_root / '.ccb' / 'ccb.config'

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -44,6 +44,7 @@ from provider_backends.codex import launcher as codex_launcher
 from provider_backends.codex.launcher_runtime.command import (
     prepare_codex_home_overrides as prepare_codex_home_overrides_for_test,
 )
+from provider_backends.codex.launcher_runtime.command_runtime import service as codex_command_service
 from provider_backends.codex.session_authority import (
     current_provider_authority_fingerprint,
 )
@@ -4379,6 +4380,39 @@ def test_codex_launcher_build_start_cmd_exports_inherited_api_env(monkeypatch, t
 
     assert f'OPENAI_API_KEY={shlex.quote("env-key")}' in cmd
     assert f'OPENAI_BASE_URL={shlex.quote("https://api.example.test/v1")}' in cmd
+
+
+def test_codex_launcher_build_start_cmd_does_not_export_model_catalog_json(
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / 'runtime'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    profile = ResolvedProviderProfile(
+        provider='codex',
+        agent_name='agent1',
+        mode='isolated',
+        runtime_home=str(tmp_path / 'managed-codex-home'),
+        env={'model_catalog_json': 'model.json'},
+    )
+
+    spec = _spec('agent1')
+    command = ParsedStartCommand(project=None, agent_names=('agent1',), restore=False, auto_permission=False)
+
+    cmd = codex_command_service.build_start_cmd(
+        command,
+        spec,
+        runtime_dir,
+        'sess-model-catalog',
+        load_resolved_provider_profile_fn=lambda _: profile,
+        prepare_codex_home_overrides_fn=lambda *_, **__: {'CODEX_HOME': str(tmp_path / 'managed-codex-home')},
+        provider_start_parts_fn=lambda _: ['codex'],
+        load_resume_session_id_fn=lambda *_, **__: None,
+        build_codex_shell_prefix_fn=lambda **_: [],
+        supports_managed_app_server_fn=lambda _: False,
+        prepared_state={'project_root': tmp_path, 'workspace_path': tmp_path},
+    )
+
+    assert 'model_catalog_json=' not in cmd
 
 
 def test_codex_launcher_build_start_cmd_exports_user_session_transport_without_runtime_leaks(


### PR DESCRIPTION
### 目标
支持 `agents.<name>.model_catalog_json`，把 codex 模型目录写入 managed 配置，并让 `agent.model` 覆盖全局继承的模型。

### 改动
- 解析层允许 `agents.<name>.model_catalog_json`，并入 `provider_profile.env`；渲染层同步序列化
- managed codex `config.toml` 写入 `model_catalog_json` 并把 `models.json` 侧车文件复制进 managed home
- `agent.model` 显式写回 managed `config.toml`，覆盖从全局 `~/.codex/config.toml` 继承的 model（修复 `/model` 显示被全局模型覆盖的问题）
- `prepare_codex_home_overrides` / `provider_hooks` 从实时 spec 透传 `model` 与 `model_catalog_json`，避免 relaunch/respawn 使用过期缓存 profile
- 补充 `provider_profiles` / `config_loader` / `runtime_launch` 单元测试

### 测试
新增/更新 `test_provider_profiles.py`、`test_v2_config_loader.py`、`test_v2_runtime_launch.py`。
