### PR TITLE
fix(windows): subprocess 输出显式指定 utf-8 编码

### DIFF
--- a/dev_tools/perf_phase0_baseline.py
+++ b/dev_tools/perf_phase0_baseline.py
@@ -409,7 +409,7 @@ def _tool_probe(command: list[str]) -> dict[str, Any]:
     if executable is None:
         return {"status": "missing", "command": command, "path": None}
     try:
-        cp = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
+        cp = subprocess.run(command, text=True, encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
     except Exception as exc:
         return {"status": "error", "command": command, "path": executable, "error": str(exc)}
     return {

--- a/lib/cli/auxiliary.py
+++ b/lib/cli/auxiliary.py
@@ -54,7 +54,7 @@ def extract_tool_name(tool: dict) -> str:
 def cmd_droid_test_delegation(_args) -> int:
     cmd = ["droid", "exec", "--list-tools", "--output-format", "json"]
     try:
-        res = subprocess.run(cmd, capture_output=True, text=True)
+        res = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
     except FileNotFoundError:
         print("❌ `droid` not found in PATH.", file=sys.stderr)
         return 2

--- a/lib/cli/kill_runtime/zombies.py
+++ b/lib/cli/kill_runtime/zombies.py
@@ -35,6 +35,7 @@ def _list_tmux_sessions() -> list[str]:
             ["tmux", "list-sessions", "-F", "#{session_name}"],
             capture_output=True,
             text=True,
+            encoding='utf-8',
             timeout=5,
         )
     except Exception:

--- a/lib/workspace/materializer.py
+++ b/lib/workspace/materializer.py
@@ -220,7 +220,7 @@ class WorkspaceMaterializer:
         return path.resolve()
 
     def _run(self, args: list[str], *, error: str) -> None:
-        result = subprocess.run(args, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(args, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or '').strip()
             raise RuntimeError(f'{error}: {detail}')

--- a/scripts/probe_codex_pane_status.py
+++ b/scripts/probe_codex_pane_status.py
@@ -116,7 +116,7 @@ def redact_text(text: str) -> str:
 
 
 def run_command(args: list[str], *, timeout: float = 5.0, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, text=True, capture_output=True, timeout=timeout, env=env, check=False)
+    return subprocess.run(args, text=True, encoding="utf-8", capture_output=True, timeout=timeout, env=env, check=False)
 
 
 def tmux(socket_path: Path, args: list[str], *, timeout: float = 5.0) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
### 目标
Windows 下 `subprocess.run` 未指定 `encoding` 时使用 locale 默认编码，中文输出会乱码或导致解析异常。

### 改动
为以下 5 处 `subprocess` 调用统一补上 `encoding="utf-8"`：
- `dev_tools/perf_phase0_baseline.py`（工具探测）
- `lib/cli/auxiliary.py`（droid 工具列表）
- `lib/cli/kill_runtime/zombies.py`（tmux 会话清理）
- `lib/workspace/materializer.py`（工作区命令）
- `scripts/probe_codex_pane_status.py`（codex 面板状态探测）

### 测试
行为等价修复，无新增测试。
