### PR TITLE
fix(pi): use /new for context clear

### DIFF
--- a/lib/ccbd/handlers/project_clear.py
+++ b/lib/ccbd/handlers/project_clear.py
@@ -8,6 +8,11 @@ from agents.models import normalize_agent_name
 from terminal_runtime import TmuxBackend
 
 OPENCODE_CLEAR_SUBMIT_DELAY_S = 0.3
+DEFAULT_CLEAR_COMMAND = '/clear'
+CLEAR_COMMANDS: dict[str, str] = {
+    # Pi starts a fresh context with /new; it does not expose /clear.
+    'pi': '/new',
+}
 
 
 def build_project_clear_context_handler(app):
@@ -100,10 +105,11 @@ def _clear_agent_context(app, *, backend, agent_name: str) -> dict[str, object]:
     pane_id = _runtime_pane_id(runtime)
     if pane_id is None:
         return {'agent': agent_name, 'status': 'skipped', 'reason': 'pane_missing'}
+    command = CLEAR_COMMANDS.get(provider, DEFAULT_CLEAR_COMMAND)
     try:
         if not backend.pane_exists(pane_id):
             return {'agent': agent_name, 'status': 'skipped', 'reason': 'pane_missing', 'pane_id': pane_id}
-        _send_clear_sequence(backend, pane_id=pane_id, provider=provider)
+        _send_clear_sequence(backend, pane_id=pane_id, command=command, provider=provider)
     except subprocess.CalledProcessError as exc:
         return {
             'agent': agent_name,
@@ -118,7 +124,7 @@ def _clear_agent_context(app, *, backend, agent_name: str) -> dict[str, object]:
             'reason': str(exc)[:200],
             'pane_id': pane_id,
         }
-    return {'agent': agent_name, 'status': 'cleared', 'pane_id': pane_id, 'command': '/clear'}
+    return {'agent': agent_name, 'status': 'cleared', 'pane_id': pane_id, 'command': command}
 
 
 def _clear_busy_gate(app, *, agent_name: str) -> dict[str, object] | None:
@@ -173,13 +179,19 @@ def _agent_provider(app, agent_name: str) -> str:
     return str(getattr(spec, 'provider', '') or '').strip().lower()
 
 
-def _send_clear_sequence(backend, *, pane_id: str, provider: str = '') -> None:
+def _send_clear_sequence(
+    backend,
+    *,
+    pane_id: str,
+    command: str = DEFAULT_CLEAR_COMMAND,
+    provider: str = '',
+) -> None:
     try:
         backend._ensure_not_in_copy_mode(pane_id)
     except Exception:
         pass
     backend._tmux_run(['send-keys', '-t', pane_id, 'C-u'], check=True, capture=True)
-    backend._tmux_run(['send-keys', '-t', pane_id, '-l', '/clear'], check=True, capture=True)
+    backend._tmux_run(['send-keys', '-t', pane_id, '-l', command], check=True, capture=True)
     if provider == 'opencode':
         # OpenCode can drop an immediate submit after restoring an old session.
         time.sleep(OPENCODE_CLEAR_SUBMIT_DELAY_S)

--- a/test/test_ccbd_project_clear.py
+++ b/test/test_ccbd_project_clear.py
@@ -95,6 +95,29 @@ def test_project_clear_context_handler_sends_provider_clear_to_all_agent_panes(m
     ]
 
 
+def test_project_clear_context_handler_uses_new_for_pi(monkeypatch) -> None:
+    backend = _FakeBackend(existing_panes={'%1'})
+    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    handler = build_project_clear_context_handler(
+        _app(
+            agents={'pi1': SimpleNamespace(provider='pi')},
+            runtimes={'pi1': SimpleNamespace(active_pane_id='%1')},
+        )
+    )
+
+    payload = handler({'agent_names': ['pi1']})
+
+    assert payload['results'] == [
+        {'agent': 'pi1', 'status': 'cleared', 'pane_id': '%1', 'command': '/new'},
+    ]
+    assert backend.calls == [
+        ('copy-mode-quit', '%1'),
+        ('send-keys', '-t', '%1', 'C-u'),
+        ('send-keys', '-t', '%1', '-l', '/new'),
+        ('send-keys', '-t', '%1', 'Enter'),
+    ]
+
+
 def test_project_clear_context_handler_targets_requested_agents_once(monkeypatch) -> None:
     backend = _FakeBackend()
     monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)


### PR DESCRIPTION
## Summary

- Route `ccb clear` for managed Pi agents to Pi's native `/new` command.
- Preserve `/clear` as the default for existing pane-backed providers.
- Report the actual command sent in the clear result.
- Add a focused regression test covering Pi command dispatch.

## Validation

- `PYTHONPATH="$PWD/lib" uv run --with pytest python -m pytest -q test/test_ccbd_project_clear.py` — 8 passed.
- `uv run --with ruff ruff check --select I,F lib/ccbd/handlers/project_clear.py test/test_ccbd_project_clear.py` — passed.
- `git diff --check` — passed.