### PR TITLE
fix(project-memory): end Agent turn after accepted ask

### DIFF
--- a/lib/project_memory/renderer.py
+++ b/lib/project_memory/renderer.py
@@ -6,7 +6,7 @@ from .types import ProjectMemorySource
 
 CCB_RUNTIME_COORDINATION_RULES = """## CCB Runtime Coordination Rules
 
-- CCB `ask` is submit-only: submit once, then stop. Do not wait, poll, or run `pend`/`watch`/`ping` unless diagnostics were requested.
+- CCB `ask` is submit-only. Submit once. If the submission is accepted, end the current Agent turn immediately so CCB can deliver the child result in a later turn. Do not continue task work, wait, poll, or run `pend`/`watch`/`ping` in that turn. For an explicitly requested runtime diagnosis, use only the bounded diagnostic commands required by that task.
 - Prefer `/ask <agent> <message>` when available. Shell fallback:
 
 ```bash
@@ -16,9 +16,9 @@ EOF
 ```
 
 - For a user-requested conversation reset, run `command ccb clear` for all configured agents or `command ccb clear "$AGENT"` for named agents. This sends provider-native clear input without deleting `.ccb` state, workspaces, auth, sessions, logs, or project memory.
-- During an active CCB ask task, use `ask --chain` only when the current task cannot finish without that exact child result; never add it merely to bypass a rejected plain ask. Use `ask --silence` only for independent no-result-needed work.
+- During an active CCB ask task, use `ask --chain` only when the current task cannot finish without that exact child result; never add it merely to bypass a rejected plain ask. An accepted chain submission also ends the current Agent turn; CCB resumes the parent through a result-chain continuation. Use `ask --silence` only for independent no-result-needed work.
 - Finish an inbound CCB task in its current turn. If the original caller is a registered CCB agent, CCB routes that turn's terminal result through the existing lineage; do not open a new `ask` to report completion to the original caller.
-- Direct CLI submitters read terminal results from control output such as `watch` or `trace`.
+- Outside an Agent turn, a direct CLI submitter may read terminal results from control output such as `watch` or `trace`.
 - During a CCB result-chain continuation, answer directly with the final result; do not use `ask`, `--chain`, or `--silence` to send that final result to the original caller.
 - `--silence` is not an active-job correction channel. Use `ccb followup <active_job_id> --message "<correction>"` only when the target provider advertises exact active-turn support; only `injected` is success. For `rejected`, `too_late`, or `terminal`, cancel and resubmit the complete corrected task instead of queueing a correction as ordinary work.
 - A `completed` CCB job means provider execution ended normally; it does not by itself prove business acceptance.

--- a/test/test_project_memory.py
+++ b/test/test_project_memory.py
@@ -290,16 +290,22 @@ def test_materialize_runtime_memory_bundle_writes_generated_bundle(tmp_path: Pat
     assert f'workspace_path: {workspace.resolve()}' in text
     assert '## CCB Runtime Coordination Rules' in text
     assert 'CCB `ask` is submit-only' in text
-    assert 'Do not wait, poll, or run `pend`/`watch`/`ping`' in text
+    assert 'If the submission is accepted, end the current Agent turn immediately' in text
+    assert 'Do not continue task work, wait, poll' in text
+    assert 'wait, poll, or run `pend`/`watch`/`ping` in that turn' in text
+    assert 'For an explicitly requested runtime diagnosis' in text
+    assert 'use only the bounded diagnostic commands required by that task' in text
     assert 'run `command ccb clear` for all configured agents' in text
     assert 'without deleting `.ccb` state, workspaces, auth, sessions, logs, or project memory' in text
     assert 'use `ask --chain` only when the current task cannot finish without that exact child result' in text
     assert 'never add it merely to bypass a rejected plain ask' in text
+    assert 'An accepted chain submission also ends the current Agent turn' in text
+    assert 'CCB resumes the parent through a result-chain continuation' in text
     assert 'Finish an inbound CCB task in its current turn' in text
     assert 'If the original caller is a registered CCB agent' in text
     assert "routes that turn's terminal result through the existing lineage" in text
     assert 'do not open a new `ask` to report completion to the original caller' in text
-    assert 'Direct CLI submitters read terminal results from control output' in text
+    assert 'Outside an Agent turn, a direct CLI submitter may read terminal results' in text
     assert 'such as `watch` or `trace`' in text
     assert 'During a CCB result-chain continuation, answer directly with the final result' in text
     assert 'do not use `ask`, `--chain`, or `--silence`' in text

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -4468,7 +4468,8 @@ def test_materialize_codex_home_config_writes_project_memory_bundle(tmp_path: Pa
     assert 'provider: codex' in text
     assert '## CCB Runtime Coordination Rules' in text
     assert 'CCB `ask` is submit-only' in text
-    assert 'Do not wait, poll, or run `pend`/`watch`/`ping`' in text
+    assert 'If the submission is accepted, end the current Agent turn immediately' in text
+    assert 'wait, poll, or run `pend`/`watch`/`ping` in that turn' in text
     assert text.index('## CCB Runtime Coordination Rules') < text.index('## CCB Shared Project Memory')
     assert '## Provider User Memory' in text
     assert 'user codex memory' in text


### PR DESCRIPTION
## Problem

The generated runtime coordination rule described CCB `ask` as submit-only and said to "submit once, then stop." It prohibited polling, but it did not state that a successful submission must end the current Agent turn.

That ambiguity permits an Agent to interpret "stop" as active waiting with a shell delay or another keep-alive action. It also leaves the result-chain route unclear and does not distinguish Agent-turn behavior from a direct CLI user who intentionally reads control output.

## Approach

Make the successful route explicit in generated runtime memory:

- after an accepted plain `ask`, end the current Agent turn immediately and let CCB deliver the result later;
- after an accepted `ask --chain`, also end the turn and let CCB resume the parent through a result-chain continuation;
- reserve `pend`, `watch`, `ping`, and similar observation for a bounded runtime-diagnosis task;
- describe `watch` and `trace` as direct-CLI control output outside an Agent turn.

The change is limited to the generated coordination renderer and its contract tests. It does not change dispatcher, queue, callback, or CLI execution semantics.

## Result

The injected rule now gives Agents one unambiguous successful action: return control to CCB after submission. Chain continuations remain explicit, while legitimate direct-CLI observation is no longer conflated with in-turn waiting.

## Verification

- The complete project-memory test file and the Codex materialization contract test passed: 15 tests total.
- The changed Python module compiled successfully.
- `git diff --check` passed.

## Scope

The wording appears in newly materialized runtime memory. Existing running sessions do not gain the clarification until their normal supported refresh path rematerializes the bundle.