### PR TITLE
fix(ci): allow fork checkout for Windows PR isolation

### DIFF
--- a/.github/workflows/windows-pr-isolation.yml
+++ b/.github/workflows/windows-pr-isolation.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Fork PR heads are data only: the checker below always runs from the
+      # trusted base checkout in policy/. Required after actions/checkout began
+      # blocking fork refs under pull_request_target by default.
       - name: Checkout untrusted PR head as data
         uses: actions/checkout@v4
         with:
@@ -34,6 +37,7 @@ jobs:
           path: pr
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Import trusted base history into PR checkout
         shell: bash

--- a/test/test_windows_pr_isolation.py
+++ b/test/test_windows_pr_isolation.py
@@ -231,6 +231,7 @@ def test_windows_pr_isolation_workflow_uses_trusted_base_policy() -> None:
     assert "repository: ${{ github.event.pull_request.head.repo.full_name }}" in text
     assert "path: policy" in text
     assert "path: pr" in text
+    assert "allow-unsafe-pr-checkout: true" in text
     assert "github.event.pull_request.base.sha" in text
     assert "github.event.pull_request.head.sha" in text
     assert 'checker="${GITHUB_WORKSPACE}/policy/platforms/windows/tools/check_pr_isolation.py"' in text


### PR DESCRIPTION
## Summary
- Opt in to `allow-unsafe-pr-checkout` only on the untrusted PR-head checkout step in `windows-pr-isolation.yml`.
- Keep the isolation checker running from the trusted base `policy/` checkout.
- Update the workflow contract test to require the opt-in flag.

This restores the Windows PR Isolation check for fork PRs after `actions/checkout` began refusing fork refs under `pull_request_target` by default (seen on #330).

## Test plan
- [x] `python3 -m pytest test/test_windows_pr_isolation.py::test_windows_pr_isolation_workflow_uses_trusted_base_policy` → passed
- [ ] After merge / on this PR: confirm **Windows changes stay in Windows ownership** gets past checkout for a fork PR (may still need maintainer workflow approval for first-time fork runs)
- [ ] Note: `test_current_shared_windows_reverse_dependencies_do_not_expand` currently fails on `main` due to a pre-existing `service_graph` → `herdr.lifecycle_bridge` allowlist gap; intentionally out of scope for this PR