### PR TITLE
feat(mobile): 支持多 host 及 host 自定义名称

### DIFF
--- a/mobile/app/lib/features/project_home/home_terminal_host_picker_sheet.dart
+++ b/mobile/app/lib/features/project_home/home_terminal_host_picker_sheet.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/ccb_mobile_localizations.dart';
+import '../../pairing/gateway_pairing.dart';
+import 'project_home_gateway_profiles.dart';
+
+/// One computer offered as a host terminal target. The status line is prepared by
+/// the caller, which is the only place that knows each host's connection state.
+class HomeTerminalHostOption {
+  const HomeTerminalHostOption({
+    required this.profile,
+    required this.statusLabel,
+    this.customName,
+    this.available = true,
+  });
+
+  final GatewayPairedHost profile;
+
+  /// Short connection state of this computer, shown under its name.
+  final String statusLabel;
+
+  /// Name the user chose for this computer, or null while it still shows the
+  /// name derived from its pairing.
+  final String? customName;
+
+  /// False when this computer cannot open a terminal, either because pairing did
+  /// not grant terminal access or because the computer is unreachable.
+  final bool available;
+
+  /// Stable identity of this option, matching the aggregated project list keys.
+  String get key => projectHomeGatewayProfileKey(profile);
+}
+
+/// Asks which paired computer should own the terminal. Returns the chosen host,
+/// or null when the sheet is dismissed without a choice.
+Future<GatewayPairedHost?> showHomeTerminalHostPickerSheet(
+  BuildContext context, {
+  required List<HomeTerminalHostOption> options,
+}) {
+  return showModalBottomSheet<GatewayPairedHost>(
+    context: context,
+    showDragHandle: true,
+    builder: (context) => _HomeTerminalHostPickerSheet(options: options),
+  );
+}
+
+/// Host list of [showHomeTerminalHostPickerSheet]. Kept private so the sheet is
+/// always entered through the function that supplies the modal route.
+class _HomeTerminalHostPickerSheet extends StatelessWidget {
+  const _HomeTerminalHostPickerSheet({required this.options});
+
+  final List<HomeTerminalHostOption> options;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final strings = CcbMobileLocalizations.of(context);
+    return SafeArea(
+      child: Column(
+        key: const ValueKey('home-terminal-host-picker-sheet'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  strings.openTerminal,
+                  style: theme.textTheme.titleLarge,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  strings.chooseTerminalHost,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Flexible(
+            child: ListView.separated(
+              key: const ValueKey('home-terminal-host-list'),
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              shrinkWrap: true,
+              itemCount: options.length,
+              separatorBuilder: (context, index) => const Divider(height: 1),
+              itemBuilder:
+                  (context, index) => _HostOptionTile(option: options[index]),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One selectable computer. An unavailable computer stays visible but greyed out
+/// so a paired host never silently disappears from the target list.
+class _HostOptionTile extends StatelessWidget {
+  const _HostOptionTile({required this.option});
+
+  final HomeTerminalHostOption option;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final enabled = option.available;
+    return ListTile(
+      key: ValueKey('home-terminal-host-${option.key}'),
+      enabled: enabled,
+      leading: Icon(
+        enabled ? Icons.computer : Icons.cloud_off_outlined,
+        color: enabled ? null : colorScheme.onSurfaceVariant,
+      ),
+      title: Text(
+        projectHomeGatewayProfileHostName(
+          option.profile,
+          customName: option.customName,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        option.statusLabel,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap:
+          enabled
+              ? () => Navigator.of(context).pop(option.profile)
+              : null,
+    );
+  }
+}

--- a/mobile/app/lib/features/project_home/project_home_gateway_profiles.dart
+++ b/mobile/app/lib/features/project_home/project_home_gateway_profiles.dart
@@ -13,6 +13,46 @@ String projectHomeGatewayProfileLabel(GatewayPairedHost profile) {
   return '${profile.profile.hostId} / ${profile.profile.deviceId} / $routeLabel';
 }
 
+/// Short human-facing name of a paired computer, used where several hosts are
+/// listed together. A [customName] chosen on this phone always wins; otherwise
+/// the pairing contract carries no computer name, so the paired project id is
+/// preferred and an abbreviated host id is the fallback.
+String projectHomeGatewayProfileHostName(
+  GatewayPairedHost profile, {
+  String? customName,
+}) {
+  final chosen = customName?.trim() ?? '';
+  if (chosen.isNotEmpty) {
+    return chosen;
+  }
+  final projectId = profile.projectId?.trim() ?? '';
+  if (projectId.isNotEmpty) {
+    return projectId;
+  }
+  final hostId = profile.profile.hostId.trim();
+  return hostId.length <= 12 ? hostId : '${hostId.substring(0, 12)}…';
+}
+
+/// Name the user gave one paired computer, or null while that computer still
+/// carries its pairing-derived name. [customNames] is the map returned by
+/// [GatewayHostProfileStore.listHostNames].
+String? projectHomeCustomHostName(
+  Map<String, String> customNames,
+  GatewayPairedHost profile,
+) {
+  final name =
+      customNames[projectHomeCustomHostNameKey(profile)]?.trim() ?? '';
+  return name.isEmpty ? null : name;
+}
+
+/// Key of one paired computer inside a custom host name map.
+String projectHomeCustomHostNameKey(GatewayPairedHost profile) {
+  return GatewayHostProfileStore.hostNameKey(
+    hostId: profile.profile.hostId,
+    deviceId: profile.profile.deviceId,
+  );
+}
+
 List<GatewayPairedHost> sortProjectHomeGatewayProfiles(
   Iterable<GatewayPairedHost> profiles,
 ) {

--- a/mobile/app/lib/features/project_home/project_home_host_rename_dialog.dart
+++ b/mobile/app/lib/features/project_home/project_home_host_rename_dialog.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/ccb_mobile_localizations.dart';
+
+/// Longest computer name that is still readable inside a group header, so a
+/// pasted path or token cannot push the status label off the row.
+const projectHomeHostNameMaxLength = 40;
+
+/// Outcome of [showProjectHomeHostRenameDialog]: either the name the user typed
+/// or an explicit reset back to the pairing-derived name. Dismissing the dialog
+/// yields no result at all, so cancelling never rewrites a stored name.
+class ProjectHomeHostRenameResult {
+  const ProjectHomeHostRenameResult._(this.name);
+
+  /// The user chose an explicit name for this computer.
+  const ProjectHomeHostRenameResult.named(String name) : this._(name);
+
+  /// The user cleared the name, so the pairing-derived name applies again.
+  const ProjectHomeHostRenameResult.automatic() : this._(null);
+
+  /// Chosen name, or null when the pairing-derived name should be restored.
+  final String? name;
+}
+
+/// Asks for the name of one paired computer, prefilled with its current name.
+/// Returns null when the dialog is dismissed, so the stored name is left alone.
+Future<ProjectHomeHostRenameResult?> showProjectHomeHostRenameDialog(
+  BuildContext context, {
+  required String automaticName,
+  String? currentName,
+}) {
+  return showDialog<ProjectHomeHostRenameResult>(
+    context: context,
+    builder:
+        (context) => _ProjectHomeHostRenameDialog(
+          automaticName: automaticName,
+          currentName: currentName,
+        ),
+  );
+}
+
+/// Name field of [showProjectHomeHostRenameDialog]. Kept private so the dialog
+/// is always entered through the function that supplies the modal route.
+class _ProjectHomeHostRenameDialog extends StatefulWidget {
+  const _ProjectHomeHostRenameDialog({
+    required this.automaticName,
+    required this.currentName,
+  });
+
+  /// Name this computer falls back to, shown as the hint of an empty field.
+  final String automaticName;
+
+  /// Name the user chose earlier, or null while the automatic name is in use.
+  final String? currentName;
+
+  @override
+  State<_ProjectHomeHostRenameDialog> createState() =>
+      _ProjectHomeHostRenameDialogState();
+}
+
+class _ProjectHomeHostRenameDialogState
+    extends State<_ProjectHomeHostRenameDialog> {
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.currentName ?? '',
+  );
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Closes with the typed name, treating a field the user emptied as a reset so
+  /// clearing the text has the same effect as the explicit reset action.
+  void _submit() {
+    final name = _controller.text.trim();
+    Navigator.of(context).pop(
+      name.isEmpty
+          ? const ProjectHomeHostRenameResult.automatic()
+          : ProjectHomeHostRenameResult.named(name),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final strings = CcbMobileLocalizations.of(context);
+    return AlertDialog(
+      key: const ValueKey('host-rename-dialog'),
+      title: Text(strings.renameHost),
+      content: TextField(
+        key: const ValueKey('host-rename-field'),
+        controller: _controller,
+        autofocus: true,
+        maxLength: projectHomeHostNameMaxLength,
+        textInputAction: TextInputAction.done,
+        onSubmitted: (_) => _submit(),
+        decoration: InputDecoration(
+          labelText: strings.hostNameLabel,
+          hintText: widget.automaticName,
+          helperText: strings.hostNameHelp,
+          helperMaxLines: 2,
+        ),
+      ),
+      actions: [
+        if (widget.currentName != null)
+          TextButton(
+            key: const ValueKey('host-rename-reset'),
+            onPressed:
+                () => Navigator.of(
+                  context,
+                ).pop(const ProjectHomeHostRenameResult.automatic()),
+            child: Text(strings.useAutomaticHostName),
+          ),
+        TextButton(
+          key: const ValueKey('host-rename-cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(strings.cancel),
+        ),
+        TextButton(
+          key: const ValueKey('host-rename-save'),
+          onPressed: _submit,
+          child: Text(strings.save),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/app/lib/features/project_home/project_home_multi_host_list.dart
+++ b/mobile/app/lib/features/project_home/project_home_multi_host_list.dart
@@ -1,0 +1,441 @@
+import 'package:flutter/material.dart';
+
+import '../../app/chat_background.dart';
+import '../../l10n/ccb_mobile_localizations.dart';
+import '../../pairing/gateway_pairing.dart';
+import 'project_home_gateway_profiles.dart';
+import 'project_home_multi_host_projects.dart';
+import 'project_list.dart';
+
+/// Aggregated project list across every paired computer, grouped into one
+/// section per computer. Each section header names its owning host, so projects
+/// that share an id across computers stay distinguishable.
+class ProjectHomeMultiHostProjectListHost extends StatelessWidget {
+  const ProjectHomeMultiHostProjectListHost({
+    required this.result,
+    required this.onRefreshProjects,
+    required this.onOpenTerminal,
+    required this.onOpenSettings,
+    required this.onOpenProject,
+    required this.onRenameHost,
+    this.customHostNames = const {},
+    this.unreadProjectIds = const {},
+    this.workingProjectIds = const {},
+    super.key,
+  });
+
+  final ProjectHomeMultiHostProjectsResult result;
+  final VoidCallback onRefreshProjects;
+  final VoidCallback onOpenTerminal;
+  final VoidCallback onOpenSettings;
+  final ValueChanged<ProjectHomeHostProject> onOpenProject;
+
+  /// Opens the rename flow of one computer, so a group header can carry a name
+  /// the user recognises instead of the identifier the pairing carried.
+  final ValueChanged<GatewayPairedHost> onRenameHost;
+
+  /// Names the user chose for paired computers, keyed by
+  /// [projectHomeCustomHostNameKey].
+  final Map<String, String> customHostNames;
+  final Set<String> unreadProjectIds;
+  final Set<String> workingProjectIds;
+
+  @override
+  Widget build(BuildContext context) {
+    final strings = CcbMobileLocalizations.of(context);
+    final hasBackground = ccbWorkspaceBackgroundEnabled(context);
+    final scaffold = Scaffold(
+      backgroundColor: hasBackground ? Colors.transparent : null,
+      body: SafeArea(
+        child: Padding(
+          key: const ValueKey('multi-host-project-list-screen'),
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              strings.hostsOnline(
+                                result.onlineHostCount,
+                                result.hostCount,
+                              ),
+                              key: const ValueKey(
+                                'multi-host-project-list-summary',
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(
+                                context,
+                              ).textTheme.bodySmall?.copyWith(
+                                color:
+                                    Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                          // A host that has not answered yet is not counted as
+                          // online, so the count is marked as still settling.
+                          if (result.catalogs.any((catalog) => catalog.pending))
+                            const Padding(
+                              key: ValueKey(
+                                'multi-host-project-list-progress',
+                              ),
+                              padding: EdgeInsets.only(left: 8),
+                              child: SizedBox(
+                                width: 12,
+                                height: 12,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    key: const ValueKey('project-list-refresh-action'),
+                    tooltip: strings.refreshProjects,
+                    onPressed: onRefreshProjects,
+                    icon: const Icon(Icons.refresh),
+                  ),
+                  IconButton(
+                    key: const ValueKey('project-list-terminal-action'),
+                    tooltip: strings.openTerminal,
+                    onPressed: onOpenTerminal,
+                    icon: const Icon(Icons.terminal),
+                  ),
+                  IconButton(
+                    key: const ValueKey('project-list-settings-action'),
+                    tooltip: strings.settings,
+                    onPressed: onOpenSettings,
+                    icon: const Icon(Icons.settings_outlined),
+                  ),
+                ],
+              ),
+              Expanded(child: _buildBody(strings)),
+            ],
+          ),
+        ),
+      ),
+    );
+    return CcbWorkspaceBackground(child: scaffold);
+  }
+
+  /// Renders one section per paired computer: a host header followed by that
+  /// computer's project rows. A host that owns no project, is still connecting,
+  /// or failed to answer keeps its header and shows a placeholder row, so every
+  /// paired computer stays visible instead of silently disappearing.
+  Widget _buildBody(CcbMobileLocalizations strings) {
+    final pending = result.catalogs.any((catalog) => catalog.pending);
+    if (result.groups.isEmpty) {
+      return Center(
+        key: const ValueKey('multi-host-project-list-empty'),
+        child:
+            pending
+                ? const CircularProgressIndicator()
+                : Text(strings.noCcbProjectsFound),
+      );
+    }
+    final rows = _buildRows();
+    return ListView.separated(
+      key: const ValueKey('multi-host-project-list'),
+      itemCount: rows.length,
+      // Project rows inside one computer stay divided, while a new host section
+      // gets plain spacing so its header reads as the start of a group.
+      separatorBuilder: (context, index) {
+        return rows[index + 1].kind == _MultiHostRowKind.hostHeader
+            ? const SizedBox(height: 8)
+            : const Divider(height: 1, indent: 16);
+      },
+      itemBuilder: (context, index) {
+        final row = rows[index];
+        switch (row.kind) {
+          case _MultiHostRowKind.hostHeader:
+            return _HostGroupHeader(
+              group: row.group,
+              customName: projectHomeCustomHostName(
+                customHostNames,
+                row.group.profile,
+              ),
+              onRename: () {
+                onRenameHost(row.group.profile);
+              },
+            );
+          case _MultiHostRowKind.hostPlaceholder:
+            return _HostGroupPlaceholder(group: row.group);
+          case _MultiHostRowKind.hostProject:
+            final entry = row.entry!;
+            return _MultiHostProjectListTile(
+              entry: entry,
+              hasUnreadTaskCompletion: unreadProjectIds.contains(
+                entry.project.id,
+              ),
+              hasWorkingAgents:
+                  entry.project.hasWorkingAgents ||
+                  workingProjectIds.contains(entry.project.id),
+              onOpen: () {
+                onOpenProject(entry);
+              },
+            );
+        }
+      },
+    );
+  }
+
+  /// Flattens the per-computer groups into renderable rows, keeping each group's
+  /// header directly above the rows it owns.
+  List<_MultiHostRow> _buildRows() {
+    return [
+      for (final group in result.groups) ...[
+        _MultiHostRow.header(group),
+        if (group.isEmpty)
+          _MultiHostRow.placeholder(group)
+        else
+          for (final entry in group.entries)
+            _MultiHostRow.project(group: group, entry: entry),
+      ],
+    ];
+  }
+}
+
+/// Kind of a rendered line in the grouped list.
+enum _MultiHostRowKind { hostHeader, hostProject, hostPlaceholder }
+
+/// One rendered line of the aggregated list: a computer header, one of that
+/// computer's projects, or a placeholder standing in for a computer that owns no
+/// project row. Each line carries the group it belongs to, so the renderer can
+/// draw it without looking back for its owning computer.
+class _MultiHostRow {
+  const _MultiHostRow.header(this.group)
+    : kind = _MultiHostRowKind.hostHeader,
+      entry = null;
+
+  const _MultiHostRow.placeholder(this.group)
+    : kind = _MultiHostRowKind.hostPlaceholder,
+      entry = null;
+
+  /// Project lines always carry their entry, so rendering never has to guard
+  /// against a project row without a project.
+  const _MultiHostRow.project({
+    required this.group,
+    required ProjectHomeHostProject this.entry,
+  }) : kind = _MultiHostRowKind.hostProject;
+
+  final _MultiHostRowKind kind;
+  final ProjectHomeHostGroup group;
+
+  /// Set only for [_MultiHostRowKind.hostProject] lines.
+  final ProjectHomeHostProject? entry;
+}
+
+/// One project row inside a computer's section. The owning computer is carried
+/// by the section header, so the row itself only renders project detail and is
+/// indented to read as a child of that header.
+class _MultiHostProjectListTile extends StatelessWidget {
+  const _MultiHostProjectListTile({
+    required this.entry,
+    required this.onOpen,
+    required this.hasUnreadTaskCompletion,
+    required this.hasWorkingAgents,
+  });
+
+  final ProjectHomeHostProject entry;
+  final VoidCallback onOpen;
+  final bool hasUnreadTaskCompletion;
+  final bool hasWorkingAgents;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final project = entry.project;
+    final root = project.root.trim();
+    final health = project.health.trim();
+    return ProjectWorkingRowHighlight(
+      projectId: project.id,
+      hasWorkingAgents: hasWorkingAgents,
+      child: ListTile(
+        key: ValueKey('multi-host-project-open-${entry.key}'),
+        contentPadding: const EdgeInsets.fromLTRB(24, 8, 16, 8),
+        leading: ProjectAttentionAvatar(
+          projectId: project.id,
+          favorite: project.favorite,
+          hasUnreadTaskCompletion: hasUnreadTaskCompletion,
+          hasWorkingAgents: hasWorkingAgents,
+        ),
+        title: Text(
+          project.displayName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleMedium,
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (root.isNotEmpty)
+              Text(root, maxLines: 1, overflow: TextOverflow.ellipsis),
+            if (health.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                health,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onOpen,
+      ),
+    );
+  }
+}
+
+/// Section header naming the computer that owns the rows below it, together with
+/// its connection state, project count, and a rename action. The name takes the
+/// remaining width so a long computer name ellipsizes instead of overflowing the
+/// header row.
+class _HostGroupHeader extends StatelessWidget {
+  const _HostGroupHeader({
+    required this.group,
+    required this.customName,
+    required this.onRename,
+  });
+
+  final ProjectHomeHostGroup group;
+
+  /// Name the user chose for this computer, or null while it still shows the
+  /// name derived from its pairing.
+  final String? customName;
+  final VoidCallback onRename;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final strings = CcbMobileLocalizations.of(context);
+    final colorScheme = theme.colorScheme;
+    final catalog = group.catalog;
+    final offline = catalog.offline;
+    final nameColor = offline ? colorScheme.onSurfaceVariant : null;
+    return Container(
+      key: ValueKey('multi-host-group-header-${group.key}'),
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+      child: Row(
+        children: [
+          _buildLeading(colorScheme),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              projectHomeGatewayProfileHostName(
+                group.profile,
+                customName: customName,
+              ),
+              key: ValueKey('multi-host-group-name-${group.key}'),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleSmall?.copyWith(color: nameColor),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            _statusLabel(strings),
+            key: ValueKey('multi-host-group-status-${group.key}'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(width: 4),
+          // Sized down to the status line so renaming stays reachable without
+          // taking width away from the computer name.
+          IconButton(
+            key: ValueKey('multi-host-group-rename-${group.key}'),
+            tooltip: strings.renameHost,
+            onPressed: onRename,
+            padding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+            iconSize: 18,
+            color: colorScheme.onSurfaceVariant,
+            icon: const Icon(Icons.drive_file_rename_outline),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Status glyph of this computer: still contacting, unreachable, or answered.
+  Widget _buildLeading(ColorScheme colorScheme) {
+    final catalog = group.catalog;
+    if (catalog.pending) {
+      return const SizedBox(
+        width: 14,
+        height: 14,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    }
+    return Icon(
+      catalog.offline ? Icons.cloud_off_outlined : Icons.computer,
+      size: 16,
+      color: colorScheme.onSurfaceVariant,
+    );
+  }
+
+  /// Connection state of this computer, with the project count appended once the
+  /// computer has actually answered with rows.
+  String _statusLabel(CcbMobileLocalizations strings) {
+    final catalog = group.catalog;
+    if (catalog.offline) {
+      return strings.hostOffline;
+    }
+    if (catalog.pending) {
+      return strings.hostConnecting;
+    }
+    return '${strings.hostOnline} · ${strings.hostProjectCount(group.entries.length)}';
+  }
+}
+
+/// Placeholder row keeping a computer visible when it owns no project row, so an
+/// unreachable or empty computer still accounts for itself under its header.
+class _HostGroupPlaceholder extends StatelessWidget {
+  const _HostGroupPlaceholder({required this.group});
+
+  final ProjectHomeHostGroup group;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final strings = CcbMobileLocalizations.of(context);
+    final catalog = group.catalog;
+    final label =
+        catalog.offline
+            ? strings.hostOffline
+            : catalog.pending
+            ? strings.hostConnecting
+            : strings.hostNoProjects;
+    return Padding(
+      key: ValueKey('multi-host-group-placeholder-${group.key}'),
+      padding: const EdgeInsets.fromLTRB(24, 4, 16, 12),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/project_home/project_home_multi_host_projects.dart
+++ b/mobile/app/lib/features/project_home/project_home_multi_host_projects.dart
@@ -1,0 +1,173 @@
+import '../../models/ccb_project.dart';
+import '../../pairing/gateway_pairing.dart';
+import 'project_home_gateway_profiles.dart';
+import 'project_home_runtime_activation.dart';
+
+/// One project together with the paired host that owns it. Project ids are only
+/// unique per host, so aggregated views must always carry the owning profile.
+class ProjectHomeHostProject {
+  const ProjectHomeHostProject({required this.profile, required this.project});
+
+  final GatewayPairedHost profile;
+  final CcbProject project;
+
+  /// Stable identity of this row across hosts that reuse the same project id.
+  String get key =>
+      '${projectHomeGatewayProfileKey(profile)} ${project.id}';
+}
+
+/// Outcome of listing one paired host. A host that fails to answer is reported
+/// as offline instead of failing the whole aggregated catalog.
+class ProjectHomeHostCatalog {
+  const ProjectHomeHostCatalog({
+    required this.profile,
+    required this.projects,
+    this.error,
+    this.pending = false,
+  });
+
+  final GatewayPairedHost profile;
+  final List<CcbProject> projects;
+  final Object? error;
+
+  /// True while this host is still being contacted. Cached rows are shown as
+  /// pending so the header never claims a computer is online before it answers.
+  final bool pending;
+
+  bool get online => error == null && !pending;
+
+  bool get offline => error != null;
+}
+
+/// One paired computer together with its own project rows. Groups keep every
+/// row attached to the computer that owns it, so the aggregated list can be
+/// rendered as one section per computer instead of a flat mixed list.
+class ProjectHomeHostGroup {
+  const ProjectHomeHostGroup({required this.catalog, required this.entries});
+
+  final ProjectHomeHostCatalog catalog;
+
+  /// Rows of this computer only, ordered by recent activity within the group.
+  final List<ProjectHomeHostProject> entries;
+
+  GatewayPairedHost get profile => catalog.profile;
+
+  /// Stable identity of this section, reused as the widget key of its header.
+  String get key => projectHomeGatewayProfileKey(catalog.profile);
+
+  /// True when this computer answered but owns no project, which is rendered as
+  /// an explicit empty section rather than a silently missing computer.
+  bool get isEmpty => entries.isEmpty;
+}
+
+/// Aggregated project catalog across every paired host.
+class ProjectHomeMultiHostProjectsResult {
+  const ProjectHomeMultiHostProjectsResult({
+    required this.entries,
+    required this.catalogs,
+    required this.groups,
+  });
+
+  /// Builds the aggregated view from per-host catalogs. Hosts are reported in
+  /// the order given so a slow computer never reorders the rest of the list.
+  factory ProjectHomeMultiHostProjectsResult.fromCatalogs(
+    List<ProjectHomeHostCatalog> catalogs, {
+    Map<String, DateTime> optimisticActivityAt = const {},
+  }) {
+    final groups = [
+      for (final catalog in catalogs)
+        ProjectHomeHostGroup(
+          catalog: catalog,
+          entries: sortProjectHomeHostProjects([
+            for (final project in catalog.projects)
+              ProjectHomeHostProject(
+                profile: catalog.profile,
+                project: project,
+              ),
+          ], optimisticActivityAt: optimisticActivityAt),
+        ),
+    ];
+    return ProjectHomeMultiHostProjectsResult(
+      entries: sortProjectHomeHostProjects([
+        for (final group in groups) ...group.entries,
+      ], optimisticActivityAt: optimisticActivityAt),
+      catalogs: catalogs,
+      groups: groups,
+    );
+  }
+
+  final List<ProjectHomeHostProject> entries;
+  final List<ProjectHomeHostCatalog> catalogs;
+
+  /// One section per paired computer, in the order the catalogs were given.
+  final List<ProjectHomeHostGroup> groups;
+
+  int get hostCount => catalogs.length;
+
+  int get onlineHostCount =>
+      catalogs.where((catalog) => catalog.online).length;
+}
+
+/// Lists the project catalog of one paired host. Callers fan this out per host
+/// so every computer renders as soon as it answers, independently of the others.
+class ProjectHomeMultiHostProjectsLoader {
+  const ProjectHomeMultiHostProjectsLoader({
+    required ProjectHomeGatewayRepositoryFactory repositoryFactory,
+    Duration timeout = projectHomeRuntimeViewLoadTimeout,
+  }) : _repositoryFactory = repositoryFactory,
+       _timeout = timeout;
+
+  final ProjectHomeGatewayRepositoryFactory _repositoryFactory;
+  final Duration _timeout;
+
+  /// Never throws: an unreachable computer resolves to an offline catalog so it
+  /// cannot hide the projects of the hosts that did answer.
+  Future<ProjectHomeHostCatalog> loadHost(GatewayPairedHost profile) async {
+    try {
+      final projects = await _repositoryFactory(
+        profile,
+      ).listProjects().timeout(_timeout);
+      return ProjectHomeHostCatalog(profile: profile, projects: projects);
+    } catch (error) {
+      return ProjectHomeHostCatalog(
+        profile: profile,
+        projects: const [],
+        error: error,
+      );
+    }
+  }
+}
+
+/// Orders aggregated rows by recent activity across all hosts, then by host and
+/// project id so rows from different computers keep a stable position.
+List<ProjectHomeHostProject> sortProjectHomeHostProjects(
+  List<ProjectHomeHostProject> entries, {
+  Map<String, DateTime> optimisticActivityAt = const {},
+}) {
+  final sorted = [...entries];
+  sorted.sort((left, right) {
+    final leftAt = ccbProjectRecentActivityAt(
+      left.project,
+      optimisticActivityAt: optimisticActivityAt[left.project.id],
+    );
+    final rightAt = ccbProjectRecentActivityAt(
+      right.project,
+      optimisticActivityAt: optimisticActivityAt[right.project.id],
+    );
+    if (leftAt != null && rightAt != null) {
+      final compared = rightAt.compareTo(leftAt);
+      if (compared != 0) {
+        return compared;
+      }
+    } else if (leftAt != null) {
+      return -1;
+    } else if (rightAt != null) {
+      return 1;
+    } else if (left.project.hasWorkingAgents !=
+        right.project.hasWorkingAgents) {
+      return left.project.hasWorkingAgents ? -1 : 1;
+    }
+    return left.key.compareTo(right.key);
+  });
+  return sorted;
+}

--- a/mobile/app/lib/features/project_home/project_home_screen.dart
+++ b/mobile/app/lib/features/project_home/project_home_screen.dart
@@ -33,11 +33,15 @@ import '../agent_chat/agent_execution_status.dart';
 import '../terminal/host_terminal_screen.dart';
 import 'project_home_connection_details_panel_host.dart';
 import 'gateway_lan_network_banner.dart';
+import 'home_terminal_host_picker_sheet.dart';
 import 'project_home_focus_coordinator.dart';
 import 'project_home_gateway_profiles.dart';
+import 'project_home_host_rename_dialog.dart';
 import 'project_home_lifecycle_coordinator.dart';
 import 'mobile_connection_supervisor.dart';
 import 'mobile_presence_coordinator.dart';
+import 'project_home_multi_host_list.dart';
+import 'project_home_multi_host_projects.dart';
 import 'project_home_notification_target.dart';
 import 'project_home_onboarding.dart';
 import 'project_home_pairing_flow.dart';
@@ -247,6 +251,23 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
   double _wideSidebarDragDelta = 0;
   bool _mobileAgentsCollapsed = false;
   bool _agentTerminalMode = false;
+  late final _multiHostProjectsLoader = ProjectHomeMultiHostProjectsLoader(
+    repositoryFactory: widget.gatewayRepositoryFactory,
+  );
+
+  /// Per-host catalogs keyed by [projectHomeGatewayProfileKey]. Each host lands
+  /// here on its own so a slow computer cannot delay the rest of the list.
+  final Map<String, ProjectHomeHostCatalog> _hostCatalogs = {};
+
+  /// Computer names the user chose on this phone, keyed by
+  /// [projectHomeCustomHostNameKey]. Empty until the stored names are read, so a
+  /// host header simply starts from its pairing-derived name.
+  Map<String, String> _customHostNames = const {};
+
+  /// Bumped on every aggregated reload so replies from a superseded round are
+  /// discarded instead of overwriting fresher catalogs.
+  int _hostCatalogsRevision = 0;
+
   late final MobileSnapshotStore _snapshotStore = MobileSnapshotStore();
   late final GatewayInvalidationCursorStore _invalidationCursorStore;
   GatewayInvalidationConnectionState _gatewayConnectionState =
@@ -347,6 +368,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
     _activeRepository = widget.repository;
     _viewFuture = _loadActiveProjectView();
     _bootstrapProfiles();
+    unawaited(_loadCustomHostNames());
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         unawaited(_refreshBackgroundConnectionSystemStatus());
@@ -435,11 +457,15 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
       return _buildOnboardingScaffold();
     }
     final serverProjectsFuture = _serverProjectsFuture;
-    if (_mode == AppRuntimeMode.pairedGateway &&
-        _activeProjectId.isEmpty &&
-        serverProjectsFuture != null) {
-      _setVisibleTaskCompletionTarget(projectId: null, agentName: null);
-      return _buildServerProjectList(serverProjectsFuture);
+    if (_mode == AppRuntimeMode.pairedGateway && _activeProjectId.isEmpty) {
+      if (_shouldAggregateHosts) {
+        _setVisibleTaskCompletionTarget(projectId: null, agentName: null);
+        return _buildMultiHostProjectList();
+      }
+      if (serverProjectsFuture != null) {
+        _setVisibleTaskCompletionTarget(projectId: null, agentName: null);
+        return _buildServerProjectList(serverProjectsFuture);
+      }
     }
     return FutureBuilder<CcbProjectView>(
       future: _viewFuture,
@@ -722,6 +748,25 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
     );
   }
 
+  /// Caches the catalog of an explicit host. The aggregated list reads every
+  /// paired host, including the ones that are not the active gateway.
+  void _persistHostProjectsSnapshot(
+    GatewayPairedHost profile,
+    List<CcbProject> projects,
+  ) {
+    unawaited(
+      _snapshotStore.write(
+        mobileProjectsSnapshotKey(
+          mobileSnapshotNamespace(
+            hostId: profile.profile.hostId,
+            deviceId: profile.profile.deviceId,
+          ),
+        ),
+        projectsSnapshotPayload(projects),
+      ),
+    );
+  }
+
   void _persistProjectViewSnapshot(CcbProjectView view) {
     final namespace = _snapshotNamespace;
     if (namespace == null) {
@@ -893,6 +938,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
       _selectedAgentName = null;
       _agentTerminalMode = false;
       _serverProjectsFuture = _loadServerProjects();
+      _refreshMultiHostProjects();
     });
   }
 
@@ -924,6 +970,297 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
         );
       },
     );
+  }
+
+  /// True when more than one distinct computer is paired, which is the only case
+  /// where the aggregated catalog adds anything over the active-host list. Two
+  /// profiles that share a host id are the same computer paired from different
+  /// devices or routes, so they keep the single active-host list.
+  bool get _shouldAggregateHosts {
+    if (_profiles.length < 2) {
+      return false;
+    }
+    final hostIds = <String>{
+      for (final profile in _profiles) profile.profile.hostId,
+    };
+    return hostIds.length > 1;
+  }
+
+  /// One profile per paired computer, so a host reachable by several routes or
+  /// devices shows a single row set. The active profile wins for its host, then
+  /// the most recently saved one, matching how a single computer is activated.
+  List<GatewayPairedHost> get _distinctHostProfiles {
+    final selectedKey =
+        _selectedProfile == null
+            ? null
+            : projectHomeGatewayProfileKey(_selectedProfile!);
+    final byHost = <String, GatewayPairedHost>{};
+    for (final profile in _profiles) {
+      final hostId = profile.profile.hostId;
+      final current = byHost[hostId];
+      if (current == null) {
+        byHost[hostId] = profile;
+        continue;
+      }
+      if (projectHomeGatewayProfileKey(profile) == selectedKey) {
+        byHost[hostId] = profile;
+        continue;
+      }
+      if (projectHomeGatewayProfileKey(current) == selectedKey) {
+        continue;
+      }
+      if (_isMoreRecentlySaved(profile, current)) {
+        byHost[hostId] = profile;
+      }
+    }
+    return byHost.values.toList(growable: false);
+  }
+
+  /// Orders two profiles of the same computer by save time, treating an unknown
+  /// save time as oldest so a profile with a timestamp is always preferred.
+  bool _isMoreRecentlySaved(GatewayPairedHost a, GatewayPairedHost b) {
+    final aAt = a.savedAt ?? a.createdAt;
+    final bAt = b.savedAt ?? b.createdAt;
+    if (aAt == null) {
+      return false;
+    }
+    if (bAt == null) {
+      return true;
+    }
+    return aAt.isAfter(bAt);
+  }
+
+  /// Reloads every paired computer. Safe to call when only one host is paired;
+  /// the aggregated list is simply not rendered in that case.
+  void _refreshMultiHostProjects() {
+    _hostCatalogsRevision += 1;
+    if (!_shouldAggregateHosts) {
+      _hostCatalogs.clear();
+      return;
+    }
+    final revision = _hostCatalogsRevision;
+    final profiles = _distinctHostProfiles;
+    final keys = {
+      for (final profile in profiles) projectHomeGatewayProfileKey(profile),
+    };
+    // Unpaired hosts must disappear, but catalogs of still-paired hosts are kept
+    // as the pending frame so a refresh never blanks the list.
+    _hostCatalogs.removeWhere((key, _) => !keys.contains(key));
+    for (final profile in profiles) {
+      final key = projectHomeGatewayProfileKey(profile);
+      final previous = _hostCatalogs[key];
+      _hostCatalogs[key] = ProjectHomeHostCatalog(
+        profile: profile,
+        projects: previous?.projects ?? const [],
+        pending: true,
+      );
+    }
+    unawaited(_seedMultiHostProjectsFromSnapshots(revision, profiles));
+    for (final profile in profiles) {
+      unawaited(_refreshHostCatalog(revision, profile));
+    }
+  }
+
+  /// Paints cached projects of hosts that have not answered yet, so an offline
+  /// computer no longer costs a blank screen for the whole request timeout.
+  Future<void> _seedMultiHostProjectsFromSnapshots(
+    int revision,
+    List<GatewayPairedHost> profiles,
+  ) async {
+    final seeded = <String, List<CcbProject>>{};
+    for (final profile in profiles) {
+      final key = projectHomeGatewayProfileKey(profile);
+      if ((_hostCatalogs[key]?.projects ?? const []).isNotEmpty) {
+        continue;
+      }
+      final record = await _snapshotStore.readRecord(
+        mobileProjectsSnapshotKey(
+          mobileSnapshotNamespace(
+            hostId: profile.profile.hostId,
+            deviceId: profile.profile.deviceId,
+          ),
+        ),
+      );
+      if (record == null) {
+        continue;
+      }
+      final projects = projectsFromSnapshotPayload(record.payload);
+      if (projects.isNotEmpty) {
+        seeded[key] = projects;
+      }
+    }
+    if (!mounted || revision != _hostCatalogsRevision || seeded.isEmpty) {
+      return;
+    }
+    setState(() {
+      for (final entry in seeded.entries) {
+        final catalog = _hostCatalogs[entry.key];
+        if (catalog == null || !catalog.pending || catalog.projects.isNotEmpty) {
+          continue;
+        }
+        _hostCatalogs[entry.key] = ProjectHomeHostCatalog(
+          profile: catalog.profile,
+          projects: entry.value,
+          pending: true,
+        );
+      }
+    });
+  }
+
+  /// Lists one host and publishes it as soon as it answers. The fresh catalog is
+  /// cached so the next launch can paint this computer without waiting for it.
+  Future<void> _refreshHostCatalog(
+    int revision,
+    GatewayPairedHost profile,
+  ) async {
+    final catalog = await _multiHostProjectsLoader.loadHost(profile);
+    if (catalog.online) {
+      _persistHostProjectsSnapshot(profile, catalog.projects);
+    }
+    if (!mounted || revision != _hostCatalogsRevision) {
+      return;
+    }
+    setState(() {
+      _hostCatalogs[projectHomeGatewayProfileKey(profile)] = catalog;
+    });
+  }
+
+  /// Mirrors a freshly listed catalog of the active host into the aggregated
+  /// view, so gateway invalidation events also refresh the aggregated list.
+  /// Must be called inside a `setState` block.
+  void _publishActiveHostCatalog(List<CcbProject> projects) {
+    final profile = _selectedProfile;
+    if (profile == null || !_shouldAggregateHosts) {
+      return;
+    }
+    _hostCatalogs[projectHomeGatewayProfileKey(profile)] =
+        ProjectHomeHostCatalog(profile: profile, projects: projects);
+  }
+
+  /// Aggregated view of the current per-host catalogs, ordered by paired host so
+  /// rows keep a stable position while the remaining computers are still loading.
+  ProjectHomeMultiHostProjectsResult get _multiHostProjectsResult {
+    return ProjectHomeMultiHostProjectsResult.fromCatalogs([
+      for (final profile in _distinctHostProfiles)
+        if (_hostCatalogs[projectHomeGatewayProfileKey(profile)]
+            case final catalog?)
+          catalog,
+    ], optimisticActivityAt: _optimisticProjectActivityAt);
+  }
+
+  Widget _buildMultiHostProjectList() {
+    final result = _multiHostProjectsResult;
+    if (result.catalogs.isEmpty) {
+      return const Scaffold(
+        body: SafeArea(child: Center(child: CircularProgressIndicator())),
+      );
+    }
+    return ProjectHomeMultiHostProjectListHost(
+      result: result,
+      onRefreshProjects: _retryMultiHostProjects,
+      // An aggregated list has no single implied host, so opening a terminal
+      // asks which computer to target first.
+      onOpenTerminal: () {
+        _openHomeTerminalLauncher(const []);
+      },
+      onOpenSettings: _openPairingSettings,
+      onOpenProject: _openHostProject,
+      onRenameHost: (profile) {
+        unawaited(_renameHost(profile));
+      },
+      customHostNames: _customHostNames,
+      unreadProjectIds: _unreadProjectIds,
+      workingProjectIds: _workingProjectIdsFor([
+        for (final entry in result.entries) entry.project,
+      ]),
+    );
+  }
+
+  void _retryMultiHostProjects() {
+    setState(_refreshMultiHostProjects);
+  }
+
+  /// Reads the computer names stored on this phone. A storage failure is not
+  /// fatal: every host header keeps its pairing-derived name.
+  Future<void> _loadCustomHostNames() async {
+    final names = await _readCustomHostNames();
+    if (names == null || !mounted) {
+      return;
+    }
+    setState(() {
+      _customHostNames = names;
+    });
+  }
+
+  /// Never throws: a phone whose secure storage is unavailable keeps showing the
+  /// pairing-derived computer names instead of failing the aggregated list.
+  Future<Map<String, String>?> _readCustomHostNames() async {
+    try {
+      return await widget.profileStore.listHostNames();
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Renames one paired computer. The name is stored on this phone only, because
+  /// pairing carries no computer name that the desktop could be asked to change.
+  /// The header is only repainted once the new name is actually stored.
+  Future<void> _renameHost(GatewayPairedHost profile) async {
+    final strings = CcbMobileLocalizations.of(context);
+    final key = projectHomeCustomHostNameKey(profile);
+    final result = await showProjectHomeHostRenameDialog(
+      context,
+      automaticName: projectHomeGatewayProfileHostName(profile),
+      currentName: _customHostNames[key],
+    );
+    if (result == null || !mounted) {
+      return;
+    }
+    try {
+      await widget.profileStore.writeHostName(
+        hostId: profile.profile.hostId,
+        deviceId: profile.profile.deviceId,
+        name: result.name,
+      );
+    } catch (_) {
+      if (mounted) {
+        _showSnack(strings.hostRenameFailed);
+      }
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      final names = {..._customHostNames};
+      if (result.name == null) {
+        names.remove(key);
+      } else {
+        names[key] = result.name!;
+      }
+      _customHostNames = names;
+    });
+  }
+
+  /// Opens an aggregated row. A row owned by another computer switches the
+  /// active host first so the project view and terminal talk to that host.
+  void _openHostProject(ProjectHomeHostProject entry) {
+    final selected = _selectedProfile;
+    final sameHost =
+        selected != null &&
+        projectHomeGatewayProfileKey(selected) ==
+            projectHomeGatewayProfileKey(entry.profile);
+    if (sameHost) {
+      _openServerProject(entry.project);
+      return;
+    }
+    _activateGatewayProfile(entry.profile);
+    // 切换 host 后需在下一帧打开项目，确保 repository 已切换
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _openServerProject(entry.project);
+      }
+    });
   }
 
   Widget _buildProjectCatalogError(Object error) {
@@ -1282,6 +1619,11 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
         _serverProjectsFuture = SynchronousFuture(projects);
       }
     });
+    if (_shouldAggregateHosts) {
+      // The aggregated list is what gets rendered with several paired hosts, and
+      // it already refreshes this host, so a second reload here is dead work.
+      return;
+    }
     // The cached list is only a startup frame. Authoritative data replaces it
     // in the background without requiring a user tap.
     try {
@@ -1484,6 +1826,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
       _activeRepository = session.repository;
       _activeProjectId = '';
       _serverProjectsFuture = session.projectsFuture;
+      _refreshMultiHostProjects();
       _openedProjectId = null;
       _selectedAgentName = null;
       _agentTerminalMode = false;
@@ -1594,6 +1937,9 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
     } catch (_) {
       return;
     }
+    // Unpairing drops the computer's stored name, so the header stops offering a
+    // name for a computer this phone no longer knows.
+    unawaited(_loadCustomHostNames());
     if (!_isActiveGatewayProfile(profile)) {
       return;
     }
@@ -1606,6 +1952,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
           )
           .toList(growable: false);
       _selectedProfile = null;
+      _refreshMultiHostProjects();
     });
     _requestBackgroundConnectionReconcile();
   }
@@ -2008,6 +2355,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
         if (mounted && _activeProjectId.isEmpty) {
           setState(() {
             _serverProjectsFuture = SynchronousFuture(projects);
+            _publishActiveHostCatalog(projects);
           });
         }
       } catch (_) {
@@ -2050,6 +2398,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
         if (mounted && _activeProjectId.isEmpty) {
           setState(() {
             _serverProjectsFuture = SynchronousFuture(projects);
+            _publishActiveHostCatalog(projects);
           });
         }
       } catch (_) {}
@@ -2267,6 +2616,12 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
   }
 
   Future<void> _openHomeTerminalLauncher(List<CcbProject> _) async {
+    // With several computers paired there is no single implied target, so the
+    // owning computer is asked for before a terminal is opened.
+    if (_shouldAggregateHosts) {
+      await _openHostTerminalForChosenHost();
+      return;
+    }
     final strings = CcbMobileLocalizations.of(context);
     final profile = _selectedProfile;
     final transport = _terminalTransport;
@@ -2278,6 +2633,95 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
     }
     final hostTransport = transport as HostTerminalTransport;
     await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (context) => HostTerminalScreen(transport: hostTransport),
+      ),
+    );
+  }
+
+  /// Asks which paired computer to open, then opens that computer's terminal.
+  /// The chosen host does not have to be the active one: its transport comes from
+  /// the same pool as the project list, so no host switch is needed.
+  Future<void> _openHostTerminalForChosenHost() async {
+    final strings = CcbMobileLocalizations.of(context);
+    final options = _hostTerminalOptions(strings);
+    if (!options.any((option) => option.available)) {
+      _showSnack(strings.noHostTerminalTargets);
+      return;
+    }
+    final profile = await showHomeTerminalHostPickerSheet(
+      context,
+      options: options,
+    );
+    if (profile == null || !mounted) {
+      return;
+    }
+    _openHostTerminalFor(profile);
+  }
+
+  /// Terminal targets for every paired computer, in the same order as the
+  /// aggregated project list. A computer that did not grant terminal access or is
+  /// unreachable is listed as unavailable rather than hidden.
+  List<HomeTerminalHostOption> _hostTerminalOptions(
+    CcbMobileLocalizations strings,
+  ) {
+    return [
+      for (final profile in _distinctHostProfiles)
+        _hostTerminalOption(profile, strings),
+    ];
+  }
+
+  /// Builds one terminal target, resolving its status from the host's catalog so
+  /// the picker reports the same connection state as the project list.
+  HomeTerminalHostOption _hostTerminalOption(
+    GatewayPairedHost profile,
+    CcbMobileLocalizations strings,
+  ) {
+    final customName = projectHomeCustomHostName(_customHostNames, profile);
+    if (!profile.profile.scopes.contains('host_terminal')) {
+      return HomeTerminalHostOption(
+        profile: profile,
+        statusLabel: strings.hostTerminalScopeMissing,
+        customName: customName,
+        available: false,
+      );
+    }
+    final catalog = _hostCatalogs[projectHomeGatewayProfileKey(profile)];
+    if (catalog != null && catalog.offline) {
+      return HomeTerminalHostOption(
+        profile: profile,
+        statusLabel: strings.hostOffline,
+        customName: customName,
+        available: false,
+      );
+    }
+    final connecting = catalog == null || catalog.pending;
+    return HomeTerminalHostOption(
+      profile: profile,
+      statusLabel: connecting ? strings.hostConnecting : strings.hostOnline,
+      customName: customName,
+    );
+  }
+
+  /// Opens the host terminal of one computer. The active computer reuses the
+  /// live transport, while any other one gets its own from the transport pool.
+  void _openHostTerminalFor(GatewayPairedHost profile) {
+    final strings = CcbMobileLocalizations.of(context);
+    final selected = _selectedProfile;
+    final isActive =
+        selected != null &&
+        projectHomeGatewayProfileKey(selected) ==
+            projectHomeGatewayProfileKey(profile);
+    final transport =
+        isActive
+            ? _terminalTransport
+            : widget.gatewayTerminalTransportFactory(profile);
+    if (transport is! HostTerminalTransport) {
+      _showSnack(strings.hostTerminalAccessUnavailable);
+      return;
+    }
+    final hostTransport = transport as HostTerminalTransport;
+    Navigator.of(context).push<void>(
       MaterialPageRoute(
         builder: (context) => HostTerminalScreen(transport: hostTransport),
       ),
@@ -2733,6 +3177,7 @@ class _ProjectHomeViewState extends State<_ProjectHomeView>
           _selectedAgentName = null;
           _agentTerminalMode = false;
           _serverProjectsFuture = _loadServerProjects();
+          _refreshMultiHostProjects();
         });
     }
   }

--- a/mobile/app/lib/l10n/ccb_mobile_localizations.dart
+++ b/mobile/app/lib/l10n/ccb_mobile_localizations.dart
@@ -305,6 +305,37 @@ class CcbMobileLocalizations {
 
   String get projects => isChinese ? '项目' : 'Projects';
 
+  String hostsOnline(int online, int total) =>
+      isChinese ? '$total 台主机，$online 台在线' : '$online of $total hosts online';
+
+  String get hostOffline => isChinese ? '离线' : 'Offline';
+
+  String get hostOnline => isChinese ? '在线' : 'Online';
+
+  String get hostConnecting => isChinese ? '连接中' : 'Connecting';
+
+  String hostProjectCount(int count) =>
+      isChinese ? '$count 个项目' : (count == 1 ? '1 project' : '$count projects');
+
+  String get hostNoProjects =>
+      isChinese ? '该电脑暂无项目' : 'No projects on this computer';
+
+  String get renameHost => isChinese ? '重命名电脑' : 'Rename computer';
+
+  String get hostNameLabel => isChinese ? '电脑名称' : 'Computer name';
+
+  String get hostNameHelp =>
+      isChinese
+          ? '仅保存在本机，用于区分已配对的多台电脑'
+          : 'Stored on this phone only, to tell paired computers apart';
+
+  String get useAutomaticHostName => isChinese ? '恢复默认' : 'Use default';
+
+  String get save => isChinese ? '保存' : 'Save';
+
+  String get hostRenameFailed =>
+      isChinese ? '无法保存电脑名称' : 'Could not save the computer name';
+
   String get openTerminal => isChinese ? '打开终端' : 'Open Terminal';
 
   String get computerTerminal => isChinese ? '电脑终端' : 'Computer terminal';
@@ -330,6 +361,15 @@ class CcbMobileLocalizations {
 
   String get chooseTerminalProject =>
       isChinese ? '选择项目和终端' : 'Choose a project and terminal';
+
+  String get chooseTerminalHost =>
+      isChinese ? '选择要打开终端的电脑' : 'Choose the computer to open';
+
+  String get hostTerminalScopeMissing =>
+      isChinese ? '未启用终端权限' : 'Terminal access not enabled';
+
+  String get noHostTerminalTargets =>
+      isChinese ? '没有可打开终端的电脑' : 'No computer can open a terminal';
 
   String get windows => isChinese ? '窗口' : 'Windows';
 

--- a/mobile/app/lib/pairing/gateway_pairing.dart
+++ b/mobile/app/lib/pairing/gateway_pairing.dart
@@ -520,6 +520,7 @@ class GatewayHostProfileStore {
 
   static const _indexKey = 'ccb_mobile.gateway_profiles.index';
   static const _profilePrefix = 'ccb_mobile.gateway_profiles.profile.';
+  static const _hostNamesKey = 'ccb_mobile.gateway_profiles.host_names';
   static const _lastSelectedKey = 'ccb_mobile.gateway_profiles.last_selected';
   static const _lastSuccessfulKey =
       'ccb_mobile.gateway_profiles.last_successful';
@@ -570,6 +571,53 @@ class GatewayHostProfileStore {
       }
     }
     return result;
+  }
+
+  /// Names the user gave paired computers on this phone, keyed by [hostNameKey].
+  /// A computer that was never renamed is simply absent, so callers keep falling
+  /// back to the name derived from the pairing itself.
+  Future<Map<String, String>> listHostNames() async {
+    final raw = await _secureStore.read(key: _hostNamesKey);
+    if (!_hasText(raw)) {
+      return const {};
+    }
+    try {
+      final decoded = jsonDecode(raw!);
+      if (decoded is! Map) {
+        return const {};
+      }
+      return {
+        for (final entry in decoded.entries)
+          if (_optionalText(entry.value) case final name?)
+            entry.key.toString(): name,
+      };
+    } on FormatException {
+      return const {};
+    }
+  }
+
+  /// Renames one paired computer. A null or blank [name] clears the stored name
+  /// so the computer falls back to the name derived from its pairing. The name
+  /// never leaves the phone: pairing carries no computer name to write back.
+  Future<void> writeHostName({
+    required String hostId,
+    required String deviceId,
+    required String? name,
+  }) async {
+    final key = hostNameKey(hostId: hostId, deviceId: deviceId);
+    final names = {...await listHostNames()};
+    final trimmed = _optionalText(name);
+    if (trimmed == null) {
+      if (names.remove(key) == null) {
+        return;
+      }
+    } else {
+      if (names[key] == trimmed) {
+        return;
+      }
+      names[key] = trimmed;
+    }
+    await _writeHostNames(names);
   }
 
   /// Returns the most recently verified profile, falling back to a persisted
@@ -637,6 +685,9 @@ class GatewayHostProfileStore {
     final key = _profileKey(hostId, deviceId);
     await _secureStore.delete(key: key);
     await _clearPreferenceFor(key);
+    // An unpaired computer must not leave its chosen name behind, so a computer
+    // paired again later starts from its pairing-derived name.
+    await writeHostName(hostId: hostId, deviceId: deviceId, name: null);
     final keys = await _readIndex();
     keys.remove(key);
     await _writeIndex(keys);
@@ -671,6 +722,13 @@ class GatewayHostProfileStore {
   Future<void> _writeIndex(List<String> keys) {
     final unique = keys.toSet().toList()..sort();
     return _secureStore.write(key: _indexKey, value: jsonEncode(unique));
+  }
+
+  Future<void> _writeHostNames(Map<String, String> names) {
+    if (names.isEmpty) {
+      return _secureStore.delete(key: _hostNamesKey);
+    }
+    return _secureStore.write(key: _hostNamesKey, value: jsonEncode(names));
   }
 
   Future<GatewayPairedHost?> _readPreferredFrom({
@@ -752,11 +810,20 @@ class GatewayHostProfileStore {
     return _profileKey(host.profile.hostId, host.profile.deviceId);
   }
 
-  static String _profileKey(String hostId, String deviceId) {
-    final encoded = base64Url
+  /// Stable identity of one paired computer. The profile storage key and the
+  /// host name map share this encoding, so a host or device id containing a
+  /// separator can never make one computer answer for another.
+  static String hostNameKey({
+    required String hostId,
+    required String deviceId,
+  }) {
+    return base64Url
         .encode(utf8.encode('$hostId\n$deviceId'))
         .replaceAll('=', '');
-    return '$_profilePrefix$encoded';
+  }
+
+  static String _profileKey(String hostId, String deviceId) {
+    return '$_profilePrefix${hostNameKey(hostId: hostId, deviceId: deviceId)}';
   }
 }
 

--- a/mobile/app/test/gateway_host_names_test.dart
+++ b/mobile/app/test/gateway_host_names_test.dart
@@ -1,0 +1,152 @@
+import 'package:ccb_mobile/pairing/gateway_pairing.dart';
+import 'package:ccb_mobile/transport/route_provider.dart';
+import 'package:test/test.dart';
+
+import 'support/project_home_test_fakes.dart';
+
+void main() {
+  test('paired computer has no stored name until it is renamed', () async {
+    final store = GatewayHostProfileStore(secureStore: MemorySecureStore());
+
+    expect(await store.listHostNames(), isEmpty);
+  });
+
+  test('renaming one computer keeps the other computers untouched', () async {
+    final store = GatewayHostProfileStore(secureStore: MemorySecureStore());
+
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: '公司台式机',
+    );
+    await store.writeHostName(
+      hostId: 'rhost_beta',
+      deviceId: 'phone',
+      name: 'MacBook',
+    );
+
+    expect(await store.listHostNames(), {
+      GatewayHostProfileStore.hostNameKey(
+        hostId: 'rhost_alpha',
+        deviceId: 'phone',
+      ): '公司台式机',
+      GatewayHostProfileStore.hostNameKey(
+        hostId: 'rhost_beta',
+        deviceId: 'phone',
+      ): 'MacBook',
+    });
+  });
+
+  test('a name is trimmed and a blank name clears the stored name', () async {
+    final store = GatewayHostProfileStore(secureStore: MemorySecureStore());
+    final key = GatewayHostProfileStore.hostNameKey(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+    );
+
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: '  书房主机  ',
+    );
+    expect(await store.listHostNames(), {key: '书房主机'});
+
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: '   ',
+    );
+    expect(await store.listHostNames(), isEmpty);
+  });
+
+  test('the same device id under another host keeps its own name', () async {
+    final store = GatewayHostProfileStore(secureStore: MemorySecureStore());
+
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: 'Alpha',
+    );
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'tablet',
+      name: 'Tablet route',
+    );
+
+    expect(await store.listHostNames(), hasLength(2));
+    expect(
+      await store.listHostNames(),
+      containsPair(
+        GatewayHostProfileStore.hostNameKey(
+          hostId: 'rhost_alpha',
+          deviceId: 'phone',
+        ),
+        'Alpha',
+      ),
+    );
+  });
+
+  test('unpairing a computer drops the name stored for it', () async {
+    final secureStore = MemorySecureStore();
+    final store = GatewayHostProfileStore(secureStore: secureStore);
+    final paired = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+
+    await store.save(paired);
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: '公司台式机',
+    );
+    await store.writeHostName(
+      hostId: 'rhost_beta',
+      deviceId: 'phone',
+      name: 'MacBook',
+    );
+
+    await store.delete(hostId: 'rhost_alpha', deviceId: 'phone');
+
+    expect(await store.list(), isEmpty);
+    expect(await store.listHostNames(), {
+      GatewayHostProfileStore.hostNameKey(
+        hostId: 'rhost_beta',
+        deviceId: 'phone',
+      ): 'MacBook',
+    });
+  });
+
+  test('a malformed stored name map is ignored instead of thrown', () async {
+    final secureStore = MemorySecureStore();
+    final store = GatewayHostProfileStore(secureStore: secureStore);
+    await store.writeHostName(
+      hostId: 'rhost_alpha',
+      deviceId: 'phone',
+      name: 'Alpha',
+    );
+    final key = secureStore.values.keys.firstWhere(
+      (candidate) => candidate.endsWith('.host_names'),
+    );
+    secureStore.values[key] = '["not-a-map"]';
+
+    expect(await store.listHostNames(), isEmpty);
+  });
+}
+
+GatewayPairedHost _pairedHost({
+  required String hostId,
+  required String deviceId,
+}) {
+  return GatewayPairedHost(
+    profile: GatewayHostProfile(
+      hostId: hostId,
+      deviceId: deviceId,
+      routeProvider: RouteProvider(
+        kind: RouteProviderKind.relay,
+        gatewayUrl: Uri.parse('https://relay.example.test'),
+      ),
+      scopes: const {'view'},
+    ),
+    deviceToken: '$hostId-token',
+    projectId: hostId,
+    createdAt: DateTime.utc(2026, 6, 22),
+  );
+}

--- a/mobile/app/test/project_home_gateway_profiles_test.dart
+++ b/mobile/app/test/project_home_gateway_profiles_test.dart
@@ -26,6 +26,46 @@ void main() {
     );
   });
 
+  test('a chosen computer name wins over the pairing derived name', () {
+    final profile = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+    final customNames = {
+      projectHomeCustomHostNameKey(profile): '  公司台式机  ',
+    };
+
+    expect(projectHomeCustomHostName(customNames, profile), '公司台式机');
+    expect(
+      projectHomeGatewayProfileHostName(
+        profile,
+        customName: projectHomeCustomHostName(customNames, profile),
+      ),
+      '公司台式机',
+    );
+  });
+
+  test('a computer without a chosen name keeps its pairing name', () {
+    final named = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+    final other = _pairedHost(hostId: 'rhost_beta', deviceId: 'phone');
+    final customNames = {projectHomeCustomHostNameKey(named): 'Alpha'};
+
+    expect(projectHomeCustomHostName(customNames, other), isNull);
+    expect(
+      projectHomeGatewayProfileHostName(
+        other,
+        customName: projectHomeCustomHostName(customNames, other),
+      ),
+      'rhost_beta',
+    );
+  });
+
+  test('a blank chosen name falls back to the pairing derived name', () {
+    final profile = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+    final customNames = {projectHomeCustomHostNameKey(profile): '   '};
+
+    expect(projectHomeCustomHostName(customNames, profile), isNull);
+    expect(projectHomeGatewayProfileHostName(profile, customName: '   '),
+        'rhost_alpha');
+  });
+
   test('merge replaces existing profile with same host and device', () {
     final oldProfile = _pairedHost(
       hostId: 'project',

--- a/mobile/app/test/project_home_host_rename_widget_test.dart
+++ b/mobile/app/test/project_home_host_rename_widget_test.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ccb_mobile/features/project_home/project_home_gateway_profiles.dart';
+import 'package:ccb_mobile/features/project_home/project_home_host_rename_dialog.dart';
+import 'package:ccb_mobile/features/project_home/project_home_multi_host_list.dart';
+import 'package:ccb_mobile/features/project_home/project_home_multi_host_projects.dart';
+import 'package:ccb_mobile/l10n/ccb_mobile_localizations.dart';
+import 'package:ccb_mobile/models/ccb_project.dart';
+import 'package:ccb_mobile/pairing/gateway_pairing.dart';
+import 'package:ccb_mobile/transport/route_provider.dart';
+
+void main() {
+  testWidgets('a renamed computer heads its group with the chosen name', (
+    tester,
+  ) async {
+    _usePhoneSurface(tester);
+    final renamed = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+    final untouched = _pairedHost(hostId: 'rhost_beta', deviceId: 'phone');
+
+    await tester.pumpWidget(
+      _localizedApp(
+        child: ProjectHomeMultiHostProjectListHost(
+          result: _resultFor([renamed, untouched]),
+          customHostNames: {projectHomeCustomHostNameKey(renamed): '公司台式机'},
+          onRefreshProjects: () {},
+          onOpenTerminal: () {},
+          onOpenSettings: () {},
+          onOpenProject: (_) {},
+          onRenameHost: (_) {},
+        ),
+      ),
+    );
+
+    expect(_headerName(tester, 'rhost_alpha/phone'), '公司台式机');
+    // A computer the user never renamed keeps the name its pairing carried.
+    expect(_headerName(tester, 'rhost_beta/phone'), 'rhost_beta');
+    // The rename action shares the header row, so the name must still fit.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the group header asks to rename its own computer', (
+    tester,
+  ) async {
+    _usePhoneSurface(tester);
+    final alpha = _pairedHost(hostId: 'rhost_alpha', deviceId: 'phone');
+    final beta = _pairedHost(hostId: 'rhost_beta', deviceId: 'phone');
+    final renameRequests = <String>[];
+
+    await tester.pumpWidget(
+      _localizedApp(
+        child: ProjectHomeMultiHostProjectListHost(
+          result: _resultFor([alpha, beta]),
+          onRefreshProjects: () {},
+          onOpenTerminal: () {},
+          onOpenSettings: () {},
+          onOpenProject: (_) {},
+          onRenameHost: (profile) {
+            renameRequests.add(projectHomeGatewayProfileKey(profile));
+          },
+        ),
+      ),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('multi-host-group-rename-rhost_beta/phone')),
+    );
+
+    expect(renameRequests, ['rhost_beta/phone']);
+  });
+
+  testWidgets('the rename dialog offers the pairing name as its hint', (
+    tester,
+  ) async {
+    ProjectHomeHostRenameResult? result;
+    var closed = false;
+
+    await tester.pumpWidget(
+      _localizedApp(
+        child: _RenameDialogHost(
+          automaticName: 'rhost_alpha',
+          currentName: null,
+          onClosed: (value) {
+            result = value;
+            closed = true;
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-rename-dialog')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('rhost_alpha'), findsOneWidget);
+    // Nothing to reset while the computer still shows its pairing name.
+    expect(find.byKey(const ValueKey('host-rename-reset')), findsNothing);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('host-rename-field')),
+      '  公司台式机 ',
+    );
+    await tester.tap(find.byKey(const ValueKey('host-rename-save')));
+    await tester.pumpAndSettle();
+
+    expect(closed, isTrue);
+    expect(result?.name, '公司台式机');
+  });
+
+  testWidgets('clearing the name restores the pairing derived name', (
+    tester,
+  ) async {
+    ProjectHomeHostRenameResult? result;
+    var closed = false;
+
+    await tester.pumpWidget(
+      _localizedApp(
+        child: _RenameDialogHost(
+          automaticName: 'rhost_alpha',
+          currentName: '公司台式机',
+          onClosed: (value) {
+            result = value;
+            closed = true;
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-rename-dialog')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('host-rename-reset')));
+    await tester.pumpAndSettle();
+
+    expect(closed, isTrue);
+    // A reset is a decision, so it is reported with a null name rather than as
+    // a dismissal that would leave the stored name in place.
+    expect(result, isNotNull);
+    expect(result?.name, isNull);
+  });
+
+  testWidgets('dismissing the rename dialog reports no choice at all', (
+    tester,
+  ) async {
+    ProjectHomeHostRenameResult? result;
+    var closed = false;
+
+    await tester.pumpWidget(
+      _localizedApp(
+        child: _RenameDialogHost(
+          automaticName: 'rhost_alpha',
+          currentName: '公司台式机',
+          onClosed: (value) {
+            result = value;
+            closed = true;
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open-rename-dialog')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('host-rename-cancel')));
+    await tester.pumpAndSettle();
+
+    expect(closed, isTrue);
+    expect(result, isNull);
+  });
+}
+
+/// Opens the rename dialog from a real route, so the dialog is exercised through
+/// the modal path the grouped project list uses.
+class _RenameDialogHost extends StatelessWidget {
+  const _RenameDialogHost({
+    required this.automaticName,
+    required this.currentName,
+    required this.onClosed,
+  });
+
+  final String automaticName;
+  final String? currentName;
+  final ValueChanged<ProjectHomeHostRenameResult?> onClosed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          key: const ValueKey('open-rename-dialog'),
+          onPressed: () async {
+            onClosed(
+              await showProjectHomeHostRenameDialog(
+                context,
+                automaticName: automaticName,
+                currentName: currentName,
+              ),
+            );
+          },
+          child: const Text('rename'),
+        ),
+      ),
+    );
+  }
+}
+
+String? _headerName(WidgetTester tester, String groupKey) {
+  return tester
+      .widget<Text>(find.byKey(ValueKey('multi-host-group-name-$groupKey')))
+      .data;
+}
+
+void _usePhoneSurface(WidgetTester tester) {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Widget _localizedApp({required Widget child}) {
+  return MaterialApp(
+    locale: const Locale('zh'),
+    supportedLocales: CcbMobileLocalizations.supportedLocales,
+    localizationsDelegates: GlobalMaterialLocalizations.delegates,
+    home: child,
+  );
+}
+
+ProjectHomeMultiHostProjectsResult _resultFor(List<GatewayPairedHost> hosts) {
+  return ProjectHomeMultiHostProjectsResult.fromCatalogs([
+    for (final host in hosts)
+      ProjectHomeHostCatalog(
+        profile: host,
+        projects: [
+          CcbProject(
+            id: '${host.profile.hostId}-project',
+            displayName: '${host.profile.hostId} 项目',
+            root: '/srv/${host.profile.hostId}',
+          ),
+        ],
+      ),
+  ]);
+}
+
+GatewayPairedHost _pairedHost({
+  required String hostId,
+  required String deviceId,
+}) {
+  return GatewayPairedHost(
+    profile: GatewayHostProfile(
+      hostId: hostId,
+      deviceId: deviceId,
+      routeProvider: RouteProvider(
+        kind: RouteProviderKind.relay,
+        gatewayUrl: Uri.parse('https://relay.example.test'),
+      ),
+      scopes: const {'view'},
+    ),
+    deviceToken: '$hostId-token',
+    projectId: hostId,
+    createdAt: DateTime.utc(2026, 6, 22),
+  );
+}


### PR DESCRIPTION
聚合展示多台已配对电脑的项目，支持按电脑分组；
每个 host 可自定义显示名称，配对后即可重命名。含对应测试。

- project_home 聚合多主机项目列表并按电脑分组
- host 自定义名称：配对后重命名、持久化到 gateway profiles
- 新增 gateway_host_names / project_home_gateway_profiles / project_home_host_rename_widget 测试