### PR TITLE
fix(pi): preserve runtime dependencies in profile snapshots

### DIFF
--- a/lib/provider_backends/pi/home.py
+++ b/lib/provider_backends/pi/home.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import shutil
+import tempfile
 from urllib.parse import urlparse
 
 from provider_core.one_way_inheritance import copy_regular_file
@@ -10,6 +12,7 @@ from provider_core.projected_assets import (
     copy_projected_tree_to_cache,
     seed_projected_file,
     tree_content_fingerprint,
+    tree_symlinks_are_self_contained,
 )
 from storage.atomic import atomic_write_text
 from storage.paths import ensure_provider_user_cache_dir
@@ -17,6 +20,14 @@ from storage.paths import ensure_provider_user_cache_dir
 
 _CACHE_PROJECTION_LABEL = 'pi-inherited-profile-asset'
 _FILE_HASH_CHUNK_SIZE = 64 * 1024
+
+
+class _MissingRuntimeDependency(RuntimeError):
+    pass
+
+
+class _InvalidRuntimeDependency(RuntimeError):
+    pass
 
 
 def materialize_pi_config(
@@ -103,7 +114,7 @@ def _snapshot_direct_extensions(
         if resolved_source in package_roots:
             continue
         if resolved_source.is_dir():
-            target_entry = _snapshot_tree(
+            target_entry = _snapshot_package_tree(
                 resolved_source,
                 cache_root=cache_root,
                 category='direct-extensions',
@@ -176,7 +187,7 @@ def _project_package_source(
     git_parts = _git_package_parts(source)
     if git_parts:
         installed = (source_agent / 'git' / git_parts[0] / git_parts[1]).resolve(strict=False)
-        target = _snapshot_tree(installed, cache_root=cache_root, category='git-packages')
+        target = _snapshot_package_tree(installed, cache_root=cache_root, category='git-packages')
         return str(target) if target is not None else source
 
     resolved = _resolve_source_path(source, source_agent)
@@ -184,7 +195,7 @@ def _project_package_source(
     if direct is not None:
         return str(direct)
     if resolved.is_dir():
-        target = _snapshot_tree(resolved, cache_root=cache_root, category='local-packages')
+        target = _snapshot_package_tree(resolved, cache_root=cache_root, category='local-packages')
     elif resolved.is_file():
         target = _snapshot_file(resolved, cache_root=cache_root, category='local-package-files')
     else:
@@ -207,7 +218,11 @@ def _rewrite_extensions(
             continue
         resolved = _resolve_source_path(entry, source_agent)
         if resolved.is_dir():
-            target = _snapshot_tree(resolved, cache_root=cache_root, category='explicit-extensions')
+            target = _snapshot_package_tree(
+                resolved,
+                cache_root=cache_root,
+                category='explicit-extensions',
+            )
         elif resolved.is_file():
             target = _snapshot_file(resolved, cache_root=cache_root, category='explicit-extension-files')
         else:
@@ -233,13 +248,199 @@ def _snapshot_tree(
     source_path = Path(source).expanduser()
     if not source_path.is_dir():
         return None
-    content_digest = digest or tree_content_fingerprint(source_path)
+    source_digest = tree_content_fingerprint(source_path)
+    content_digest = (
+        hashlib.sha256(f'{digest}\0{source_digest}'.encode('utf-8')).hexdigest()
+        if digest and source_digest
+        else source_digest
+    )
     if not content_digest:
         return None
     target = cache_root / category / content_digest / (target_name or source_path.name)
     if not copy_projected_tree_to_cache(source_path, target, label=_CACHE_PROJECTION_LABEL):
-        return None
+        raise RuntimeError(f'failed to publish verified Pi tree snapshot at {target}')
     return target
+
+
+def _snapshot_package_tree(
+    source: Path,
+    *,
+    cache_root: Path,
+    category: str,
+) -> Path | None:
+    source_path = Path(source).expanduser()
+    manifest = _read_json_object(source_path / 'package.json')
+    if manifest is None:
+        return _snapshot_tree(source_path, cache_root=cache_root, category=category)
+
+    staging_parent = cache_root / category
+    staging_parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=f'.{source_path.name}.ccb-package-',
+        dir=staging_parent,
+    ) as temporary:
+        candidate = Path(temporary) / source_path.name
+        _copy_runtime_package(
+            source_path,
+            candidate,
+            dependency_chain=(),
+        )
+        content_digest = tree_content_fingerprint(candidate)
+        if not content_digest:
+            return None
+        target = staging_parent / content_digest / source_path.name
+        if not copy_projected_tree_to_cache(
+            candidate,
+            target,
+            label=_CACHE_PROJECTION_LABEL,
+            marker_source=source_path,
+        ):
+            raise RuntimeError(
+                f'failed to publish verified Pi package snapshot for {source_path}'
+            )
+        return target
+
+
+def _copy_runtime_package(
+    source: Path,
+    target: Path,
+    *,
+    dependency_chain: tuple[Path, ...],
+) -> None:
+    resolved_source = source.resolve(strict=True)
+    _copy_package_payload(resolved_source, target)
+    manifest = _read_json_object(resolved_source / 'package.json')
+    if manifest is None:
+        return
+
+    required, optional = _runtime_dependency_names(manifest)
+    chain = (*dependency_chain, resolved_source)
+    for dependency in (*required, *optional):
+        dependency_source = _resolve_installed_dependency(resolved_source, dependency)
+        if dependency_source is None:
+            if dependency in optional:
+                continue
+            package_name = manifest.get('name')
+            owner = package_name if isinstance(package_name, str) else str(resolved_source)
+            raise _MissingRuntimeDependency(
+                f'Pi package {owner!r} cannot resolve runtime dependency {dependency!r}'
+            )
+        dependency_target = target / 'node_modules' / Path(*_package_name_parts(dependency))
+        dependency_target.parent.mkdir(parents=True, exist_ok=True)
+        if dependency_source in chain:
+            _copy_package_payload(dependency_source, dependency_target)
+            continue
+        _copy_runtime_package(
+            dependency_source,
+            dependency_target,
+            dependency_chain=chain,
+        )
+
+
+def _copy_package_payload(source: Path, target: Path) -> None:
+    if not tree_symlinks_are_self_contained(source, ignored_names=('node_modules',)):
+        manifest = _read_json_object(source / 'package.json')
+        package_name = manifest.get('name') if manifest is not None else None
+        owner = package_name if isinstance(package_name, str) else str(source)
+        raise RuntimeError(f'Pi package {owner!r} contains an unsafe symlink')
+    shutil.copytree(
+        source,
+        target,
+        ignore=shutil.ignore_patterns('node_modules'),
+        symlinks=True,
+    )
+
+
+def _runtime_dependency_names(manifest: dict[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    # Pi core imports are host-provided peers by contract. Third-party runtime
+    # modules must be declared in dependencies and belong in this closure.
+    package_name = manifest.get('name')
+    owner = package_name if isinstance(package_name, str) else '<unnamed>'
+    required = _dependency_keys(manifest.get('dependencies'), owner=owner)
+    optional = _dependency_keys(manifest.get('optionalDependencies'), owner=owner)
+    bundled = manifest.get('bundledDependencies', manifest.get('bundleDependencies'))
+    bundled_names = _bundled_dependency_names(bundled, owner=owner)
+    optional_set = set(optional)
+    required_names = tuple(
+        dict.fromkeys(
+            (
+                *(name for name in required if name not in optional_set),
+                *(name for name in bundled_names if name not in optional_set),
+            )
+        )
+    )
+    return required_names, tuple(dict.fromkeys(optional))
+
+
+def _dependency_keys(raw: object, *, owner: str) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict):
+        raise _InvalidRuntimeDependency(
+            f'Pi package {owner!r} has a non-object runtime dependency map'
+        )
+    names: list[str] = []
+    for name in raw:
+        if not isinstance(name, str) or not _valid_package_name(name):
+            raise _InvalidRuntimeDependency(
+                f'Pi package {owner!r} declares invalid runtime dependency {name!r}'
+            )
+        names.append(name)
+    return tuple(names)
+
+
+def _bundled_dependency_names(raw: object, *, owner: str) -> tuple[str, ...]:
+    if raw is None or isinstance(raw, bool):
+        return ()
+    if not isinstance(raw, list):
+        raise _InvalidRuntimeDependency(
+            f'Pi package {owner!r} has an invalid bundled dependency list'
+        )
+    names: list[str] = []
+    for name in raw:
+        if not isinstance(name, str) or not _valid_package_name(name):
+            raise _InvalidRuntimeDependency(
+                f'Pi package {owner!r} declares invalid runtime dependency {name!r}'
+            )
+        names.append(name)
+    return tuple(names)
+
+
+def _valid_package_name(name: str) -> bool:
+    try:
+        _package_name_parts(name)
+    except ValueError:
+        return False
+    return True
+
+
+def _package_name_parts(name: str) -> tuple[str, ...]:
+    parts = tuple(Path(name).parts)
+    valid = (
+        parts
+        and all(part not in {'', '.', '..'} for part in parts)
+        and '\\' not in name
+        and (
+            len(parts) == 1 and not name.startswith('@')
+            or len(parts) == 2 and parts[0].startswith('@') and len(parts[0]) > 1
+        )
+    )
+    if not valid:
+        raise ValueError(f'invalid package name: {name!r}')
+    return parts
+
+
+def _resolve_installed_dependency(package_root: Path, dependency: str) -> Path | None:
+    parts = _package_name_parts(dependency)
+    resolved_root = package_root.resolve(strict=True)
+    for directory in (resolved_root, *resolved_root.parents):
+        candidate = directory / 'node_modules' / Path(*parts)
+        try:
+            if candidate.is_dir():
+                return candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+    return None
 
 
 def _snapshot_file(source: Path, *, cache_root: Path, category: str) -> Path | None:
@@ -249,13 +450,17 @@ def _snapshot_file(source: Path, *, cache_root: Path, category: str) -> Path | N
         return None
     target = cache_root / category / digest / source_path.name
     if not seed_projected_file(source_path, target, label=_CACHE_PROJECTION_LABEL):
-        return None
+        raise RuntimeError(f'failed to publish verified Pi file snapshot at {target}')
+    if _file_content_fingerprint(target) != digest:
+        raise RuntimeError(f'tampered Pi file snapshot cache at {target}')
     return target
 
 
 def _file_content_fingerprint(path: Path) -> str:
     digest = hashlib.sha256()
     try:
+        digest.update(str(path.stat().st_mode & 0o7777).encode('ascii'))
+        digest.update(b'\0')
         with path.open('rb') as handle:
             for chunk in iter(lambda: handle.read(_FILE_HASH_CHUNK_SIZE), b''):
                 digest.update(chunk)

--- a/lib/provider_core/projected_assets.py
+++ b/lib/provider_core/projected_assets.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import stat
 import tempfile
 
 _HASH_CHUNK_SIZE = 64 * 1024
@@ -63,25 +64,82 @@ def route_projected_tree(
     return False
 
 
-def copy_projected_tree_to_cache(source: Path, bundle_root: Path, *, label: str = 'projected-tree') -> bool:
+def copy_projected_tree_to_cache(
+    source: Path,
+    bundle_root: Path,
+    *,
+    label: str = 'projected-tree',
+    marker_source: Path | None = None,
+) -> bool:
     source = Path(source).expanduser()
     bundle_root = Path(bundle_root).expanduser()
+    marker_authority = (
+        Path(marker_source).expanduser()
+        if marker_source is not None
+        else source
+    )
     if not source.is_dir():
         return False
-    if _tree_has_required_entries(source, bundle_root):
-        return write_projected_marker(bundle_root, label=label, mode='copy', source=source)
-    tmp_root = bundle_root.with_name(f'.{bundle_root.name}.tmp')
-    _remove_path(tmp_root)
-    tmp_root.parent.mkdir(parents=True, exist_ok=True)
+    if bundle_root.is_symlink() or not tree_symlinks_are_self_contained(source):
+        return False
+    source_fingerprint = tree_content_fingerprint(source)
+    if not source_fingerprint:
+        return False
+    if bundle_root.is_dir():
+        if (
+            not tree_symlinks_are_self_contained(bundle_root)
+            or tree_content_fingerprint(bundle_root) != source_fingerprint
+        ):
+            return False
+        return write_projected_marker(
+            bundle_root,
+            label=label,
+            mode='copy',
+            source=marker_authority,
+        )
+    bundle_root.parent.mkdir(parents=True, exist_ok=True)
+    staging_root = Path(
+        tempfile.mkdtemp(
+            prefix=f'.{bundle_root.name}.ccb-cache-',
+            dir=bundle_root.parent,
+        )
+    )
+    candidate = staging_root / 'candidate'
     try:
-        shutil.copytree(source, tmp_root)
-        _remove_path(bundle_root)
-        tmp_root.rename(bundle_root)
-        if not write_projected_marker(bundle_root, label=label, mode='copy', source=source):
+        shutil.copytree(source, candidate, symlinks=True)
+        if (
+            not tree_symlinks_are_self_contained(candidate)
+            or tree_content_fingerprint(candidate) != source_fingerprint
+        ):
+            return False
+        try:
+            candidate.rename(bundle_root)
+        except OSError:
+            # Another materializer may have published the same content-addressed
+            # bundle first. Accept only a complete winning tree.
+            if (
+                bundle_root.is_symlink()
+                or not tree_symlinks_are_self_contained(bundle_root)
+                or tree_content_fingerprint(bundle_root) != source_fingerprint
+            ):
+                return False
+        if (
+            bundle_root.is_symlink()
+            or not tree_symlinks_are_self_contained(bundle_root)
+            or tree_content_fingerprint(bundle_root) != source_fingerprint
+        ):
+            return False
+        if not write_projected_marker(
+            bundle_root,
+            label=label,
+            mode='copy',
+            source=marker_authority,
+        ):
             raise OSError(f'failed to write projection marker: {bundle_root}')
     except Exception:
-        _remove_path(tmp_root)
         return False
+    finally:
+        _remove_path(staging_root)
     return True
 
 
@@ -293,19 +351,26 @@ def tree_content_fingerprint(root: Path) -> str:
     root = Path(root).expanduser()
     digest = hashlib.sha256()
     try:
+        digest.update(b'root\0')
+        digest.update(str(stat.S_IMODE(root.stat().st_mode)).encode('ascii'))
+        digest.update(b'\0')
         for entry in sorted(root.rglob('*')):
             relative = entry.relative_to(root)
-            kind = 'd' if entry.is_dir() else 'f' if entry.is_file() else 'l' if entry.is_symlink() else 'o'
+            kind = 'l' if entry.is_symlink() else 'd' if entry.is_dir() else 'f' if entry.is_file() else 'o'
             digest.update(kind.encode('utf-8'))
             digest.update(b'\0')
             digest.update(str(relative).encode('utf-8', errors='ignore'))
             digest.update(b'\0')
-            if entry.is_file():
+            if entry.is_symlink():
+                digest.update(str(entry.readlink()).encode('utf-8', errors='ignore'))
+            elif entry.is_file():
+                digest.update(str(stat.S_IMODE(entry.stat().st_mode)).encode('ascii'))
+                digest.update(b'\0')
                 with entry.open('rb') as handle:
                     for chunk in iter(lambda: handle.read(_HASH_CHUNK_SIZE), b''):
                         digest.update(chunk)
-            elif entry.is_symlink():
-                digest.update(str(entry.readlink()).encode('utf-8', errors='ignore'))
+            elif entry.is_dir():
+                digest.update(str(stat.S_IMODE(entry.stat().st_mode)).encode('ascii'))
             digest.update(b'\0')
     except Exception:
         return ''
@@ -388,20 +453,26 @@ def _can_replace_projected_target(
     return not target.exists() and not target.is_symlink()
 
 
-def _tree_has_required_entries(source: Path, candidate: Path) -> bool:
-    if not candidate.is_dir():
-        return False
+def tree_symlinks_are_self_contained(
+    root: Path,
+    *,
+    ignored_names: tuple[str, ...] = (),
+) -> bool:
     try:
-        for entry in source.rglob('*'):
-            relative = entry.relative_to(source)
-            projected = candidate / relative
-            if entry.is_dir() and not projected.is_dir():
+        if root.is_symlink() or not root.is_dir():
+            return False
+        resolved_root = root.resolve(strict=True)
+        ignored = set(ignored_names)
+        for entry in root.rglob('*'):
+            if ignored.intersection(entry.relative_to(root).parts):
+                continue
+            if not entry.is_symlink():
+                continue
+            link = entry.readlink()
+            if link.is_absolute():
                 return False
-            if entry.is_file() and not projected.is_file():
-                return False
-            if entry.is_symlink() and not projected.exists() and not projected.is_symlink():
-                return False
-    except Exception:
+            (entry.parent / link).resolve(strict=True).relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
         return False
     return True
 
@@ -506,6 +577,7 @@ __all__ = [
     'seed_projected_file',
     'seed_projected_tree',
     'tree_content_fingerprint',
+    'tree_symlinks_are_self_contained',
     'tree_metadata_fingerprint',
     'write_projected_marker',
 ]

--- a/platforms/windows/tools/check_pr_isolation.py
+++ b/platforms/windows/tools/check_pr_isolation.py
@@ -59,7 +59,6 @@ WINDOWS_SUBJECT_MARKER = re.compile(
 ALLOWED_SHARED_WINDOWS_IMPORTS = frozenset(
     {
         ("lib/agents/config_loader_runtime/parsing_runtime/topology.py", "platforms.windows.os_platform"),
-        ("lib/ccbd/app_runtime/service_graph.py", "platforms.windows.herdr.lifecycle_bridge"),
         ("lib/ccbd/control_plane_transport/factory.py", "platforms.windows.control_plane.tcp"),
         ("lib/ccbd/handlers/ping_runtime/payloads.py", "platforms.windows.herdr.ccbd_surface_projection"),
         ("lib/ccbd/project_view/service.py", "platforms.windows.herdr.ccbd_surface_projection"),

--- a/platforms/windows/tools/check_pr_isolation.py
+++ b/platforms/windows/tools/check_pr_isolation.py
@@ -59,6 +59,7 @@ WINDOWS_SUBJECT_MARKER = re.compile(
 ALLOWED_SHARED_WINDOWS_IMPORTS = frozenset(
     {
         ("lib/agents/config_loader_runtime/parsing_runtime/topology.py", "platforms.windows.os_platform"),
+        ("lib/ccbd/app_runtime/service_graph.py", "platforms.windows.herdr.lifecycle_bridge"),
         ("lib/ccbd/control_plane_transport/factory.py", "platforms.windows.control_plane.tcp"),
         ("lib/ccbd/handlers/ping_runtime/payloads.py", "platforms.windows.herdr.ccbd_surface_projection"),
         ("lib/ccbd/project_view/service.py", "platforms.windows.herdr.ccbd_surface_projection"),

--- a/test/test_dsh_provider.py
+++ b/test/test_dsh_provider.py
@@ -36,6 +36,15 @@ from provider_core.pathing import session_filename_for_agent
 from provider_execution.base import ProviderRuntimeContext
 
 
+@pytest.fixture(autouse=True)
+def _isolate_git_identity_lookup(monkeypatch) -> None:
+    """Keep provider process doubles scoped to DSH launches."""
+    monkeypatch.setattr(
+        'provider_backends.native_cli_support.execution.managed_git_identity_env',
+        lambda **_kwargs: {},
+    )
+
+
 def _event(event_type: str, seq: int, data: dict, **extra) -> dict:
     return {
         'type': event_type,

--- a/test/test_native_cli_providers.py
+++ b/test/test_native_cli_providers.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 import shlex
+import shutil
 import sqlite3
 import subprocess
 from types import SimpleNamespace
@@ -896,6 +897,131 @@ def test_native_pi_local_package_snapshot_includes_pnpm_linked_transitive_depend
     assert projected.joinpath("node_modules/effect/node_modules/fast-check/index.js").is_file()
 
 
+def test_native_pi_local_package_snapshot_places_scoped_runtime_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    workspace = source_home / "workspace"
+    local_package = workspace / "packages" / "scoped-consumer"
+    scoped_dependency = workspace / "node_modules" / "@scope" / "runtime"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "scoped-consumer",
+                "dependencies": {"@scope/runtime": "1.0.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    scoped_dependency.mkdir(parents=True)
+    (scoped_dependency / "package.json").write_text(
+        '{"name":"@scope/runtime","version":"1.0.0"}\n',
+        encoding="utf-8",
+    )
+    (scoped_dependency / "index.js").write_text(
+        "module.exports = {};\n",
+        encoding="utf-8",
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert projected.joinpath("node_modules/@scope/runtime/index.js").is_file()
+
+
+def test_native_pi_local_package_snapshot_skips_missing_optional_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    local_package = source_home / "workspace" / "packages" / "optional-consumer"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "optional-consumer",
+                "optionalDependencies": {"missing-optional": "1.0.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert projected.joinpath("package.json").is_file()
+    assert not projected.joinpath("node_modules/missing-optional").exists()
+
+
+def test_native_pi_local_package_snapshot_includes_bundled_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    workspace = source_home / "workspace"
+    local_package = workspace / "packages" / "bundled-consumer"
+    bundled_dependency = workspace / "node_modules" / "bundled-runtime"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "bundled-consumer",
+                "bundledDependencies": ["bundled-runtime"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    bundled_dependency.mkdir(parents=True)
+    (bundled_dependency / "package.json").write_text(
+        '{"name":"bundled-runtime","version":"1.0.0"}\n',
+        encoding="utf-8",
+    )
+    (bundled_dependency / "index.js").write_text(
+        "module.exports = {};\n",
+        encoding="utf-8",
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert projected.joinpath("node_modules/bundled-runtime/index.js").is_file()
+
+
 def test_native_pi_local_package_snapshot_rejects_missing_required_dependency(
     tmp_path: Path,
     monkeypatch,
@@ -934,6 +1060,9 @@ def test_native_pi_local_package_snapshot_preserves_circular_dependency_resoluti
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is required to verify circular package loading")
+
     source_home = tmp_path / "source-home"
     source_agent = source_home / ".pi" / "agent"
     target_home = tmp_path / "managed-home"

--- a/test/test_native_cli_providers.py
+++ b/test/test_native_cli_providers.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shlex
 import sqlite3
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -733,6 +734,439 @@ def test_native_pi_projects_current_extension_profile_to_one_shared_snapshot(
     assert second_settings["extensions"] == settings["extensions"]
     assert not (target_home / ".ccb-inherited-profile").exists()
     assert not (second_home / ".ccb-inherited-profile").exists()
+
+
+def test_native_pi_local_package_snapshot_includes_hoisted_runtime_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    workspace = source_home / "workspace"
+    local_package = workspace / "packages" / "pi-accounts"
+    proper_lockfile = workspace / "node_modules" / "proper-lockfile"
+    graceful_fs = workspace / "node_modules" / "graceful-fs"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "pi-accounts",
+                "dependencies": {"proper-lockfile": "4.1.2"},
+                "pi": {"extensions": ["index.ts"]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (local_package / "index.ts").write_text(
+        'import lockfile from "proper-lockfile";\nexport default lockfile;\n',
+        encoding="utf-8",
+    )
+    proper_lockfile.mkdir(parents=True)
+    (proper_lockfile / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "proper-lockfile",
+                "version": "4.1.2",
+                "dependencies": {"graceful-fs": "4.2.11"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (proper_lockfile / "index.js").write_text('require("graceful-fs");\n', encoding="utf-8")
+    graceful_fs.mkdir(parents=True)
+    (graceful_fs / "package.json").write_text(
+        '{"name":"graceful-fs","version":"4.2.11"}\n',
+        encoding="utf-8",
+    )
+    (graceful_fs / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert projected.joinpath("node_modules/proper-lockfile/index.js").is_file()
+    assert projected.joinpath(
+        "node_modules/proper-lockfile/node_modules/graceful-fs/index.js"
+    ).is_file()
+
+    projected.joinpath(
+        "node_modules/proper-lockfile/node_modules/graceful-fs/index.js"
+    ).write_text("module.exports = { tampered: true };\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="failed to publish verified Pi package snapshot"):
+        materialize_native_login_state(
+            "pi",
+            tmp_path / "tampered-managed-home",
+            source_home=source_home,
+        )
+
+    (graceful_fs / "index.js").write_text(
+        "module.exports = { updated: true };\n",
+        encoding="utf-8",
+    )
+    second_home = tmp_path / "second-managed-home"
+    materialize_native_login_state("pi", second_home, source_home=source_home)
+
+    second_settings = json.loads(
+        (second_home / "settings.json").read_text(encoding="utf-8")
+    )
+    second_projected = Path(second_settings["packages"][0])
+    dependency_path = "node_modules/proper-lockfile/node_modules/graceful-fs/index.js"
+    assert second_projected != projected
+    assert projected.joinpath(dependency_path).read_text(encoding="utf-8") == (
+        "module.exports = { tampered: true };\n"
+    )
+    assert second_projected.joinpath(dependency_path).read_text(encoding="utf-8") == (
+        "module.exports = { updated: true };\n"
+    )
+
+
+def test_native_pi_local_package_snapshot_includes_pnpm_linked_transitive_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    workspace = source_home / "workspace"
+    local_package = workspace / "packages" / "pi-antigravity"
+    store_modules = workspace / "node_modules" / ".pnpm" / "effect@4" / "node_modules"
+    effect = store_modules / "effect"
+    fast_check = store_modules / "fast-check"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "pi-antigravity",
+                "dependencies": {"effect": "4.0.0-beta.101"},
+                "pi": {"extensions": ["index.ts"]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (local_package / "index.ts").write_text(
+        'import * as Effect from "effect";\nexport default Effect;\n',
+        encoding="utf-8",
+    )
+    effect.mkdir(parents=True)
+    (effect / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "effect",
+                "version": "4.0.0-beta.101",
+                "dependencies": {"fast-check": "4.9.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (effect / "index.js").write_text('require("fast-check");\n', encoding="utf-8")
+    fast_check.mkdir(parents=True)
+    (fast_check / "package.json").write_text(
+        '{"name":"fast-check","version":"4.9.0"}\n',
+        encoding="utf-8",
+    )
+    (fast_check / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+    package_modules = local_package / "node_modules"
+    package_modules.mkdir()
+    (package_modules / "effect").symlink_to(effect, target_is_directory=True)
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert projected.joinpath("node_modules/effect/index.js").is_file()
+    assert projected.joinpath("node_modules/effect/node_modules/fast-check/index.js").is_file()
+
+
+def test_native_pi_local_package_snapshot_rejects_missing_required_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    local_package = source_home / "workspace" / "pi-accounts"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "pi-accounts",
+                "dependencies": {"proper-lockfile": "4.1.2"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="pi-accounts.*cannot resolve runtime dependency 'proper-lockfile'",
+    ):
+        materialize_native_login_state("pi", target_home, source_home=source_home)
+
+
+def test_native_pi_local_package_snapshot_preserves_circular_dependency_resolution(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    workspace = source_home / "workspace"
+    package_a = workspace / "packages" / "cycle-a"
+    package_b = workspace / "node_modules" / "cycle-b"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    package_a.mkdir(parents=True)
+    (package_a / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cycle-a",
+                "main": "index.js",
+                "dependencies": {"cycle-b": "1.0.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_a / "index.js").write_text(
+        'exports.name = "a"; exports.b = require("cycle-b").name;\n',
+        encoding="utf-8",
+    )
+    package_b.mkdir(parents=True)
+    (package_b / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "cycle-b",
+                "main": "index.js",
+                "dependencies": {"cycle-a": "1.0.0"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_b / "index.js").write_text(
+        'exports.name = "b"; exports.a = require("cycle-a").name;\n',
+        encoding="utf-8",
+    )
+    (workspace / "node_modules" / "cycle-a").symlink_to(
+        package_a,
+        target_is_directory=True,
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(package_a)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            "const value=require(process.argv[1]); console.log(JSON.stringify(value))",
+            str(projected),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"name": "a", "b": "b"}
+    assert projected.joinpath(
+        "node_modules/cycle-b/node_modules/cycle-a/index.js"
+    ).is_file()
+
+
+@pytest.mark.parametrize("dependency", ["../escape", "foo/bar"])
+def test_native_pi_local_package_snapshot_rejects_invalid_required_dependency_name(
+    tmp_path: Path,
+    monkeypatch,
+    dependency: str,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    local_package = source_home / "workspace" / "invalid-package"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        json.dumps({"name": "invalid-package", "dependencies": {dependency: "1.0.0"}})
+        + "\n",
+        encoding="utf-8",
+    )
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="invalid-package.*invalid runtime dependency"):
+        materialize_native_login_state("pi", target_home, source_home=source_home)
+
+
+def test_native_pi_local_package_snapshot_rejects_external_payload_symlink(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    local_package = source_home / "workspace" / "external-link-package"
+    external = source_home / "external-assets"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    local_package.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        '{"name":"external-link-package"}\n',
+        encoding="utf-8",
+    )
+    external.mkdir()
+    (external / "secret.txt").write_text("outside\n", encoding="utf-8")
+    (local_package / "assets").symlink_to(external, target_is_directory=True)
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="external-link-package.*unsafe symlink"):
+        materialize_native_login_state("pi", target_home, source_home=source_home)
+
+
+def test_native_pi_local_package_snapshot_preserves_internal_payload_symlink(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    local_package = source_home / "workspace" / "internal-link-package"
+    assets = local_package / "assets"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    assets.mkdir(parents=True)
+    (local_package / "package.json").write_text(
+        '{"name":"internal-link-package"}\n',
+        encoding="utf-8",
+    )
+    (assets / "data.txt").write_text("inside\n", encoding="utf-8")
+    (local_package / "alias").symlink_to("assets", target_is_directory=True)
+    source_agent.mkdir(parents=True)
+    (source_agent / "settings.json").write_text(
+        json.dumps({"packages": [str(local_package)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = Path(settings["packages"][0])
+    assert (projected / "alias").is_symlink()
+    assert (projected / "alias").readlink() == Path("assets")
+    assert (projected / "alias" / "data.txt").read_text(encoding="utf-8") == "inside\n"
+
+
+def test_native_pi_direct_extension_file_snapshot_rejects_tampered_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    extension = source_agent / "extensions" / "standalone.ts"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    extension.parent.mkdir(parents=True)
+    extension.write_text("export const trusted = true;\n", encoding="utf-8")
+    (source_agent / "settings.json").write_text("{}\n", encoding="utf-8")
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+    settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    projected = next(
+        Path(entry)
+        for entry in settings["extensions"]
+        if isinstance(entry, str) and entry.endswith("standalone.ts")
+    )
+    projected.write_text("export const trusted = false;\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="tampered Pi file snapshot cache.*standalone.ts"):
+        materialize_native_login_state(
+            "pi",
+            tmp_path / "second-managed-home",
+            source_home=source_home,
+        )
+
+
+def test_native_pi_npm_content_drift_without_lock_change_uses_new_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / "source-home"
+    source_agent = source_home / ".pi" / "agent"
+    target_home = tmp_path / "managed-home"
+    npm_extension = source_agent / "npm" / "node_modules" / "pi-lens"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    npm_extension.mkdir(parents=True)
+    (source_agent / "npm" / "package-lock.json").write_text(
+        '{"packages":{"node_modules/pi-lens":{"version":"1.0.0"}}}\n',
+        encoding="utf-8",
+    )
+    (npm_extension / "package.json").write_text(
+        '{"name":"pi-lens","version":"1.0.0"}\n',
+        encoding="utf-8",
+    )
+    (npm_extension / "index.ts").write_text("old\n", encoding="utf-8")
+    (source_agent / "settings.json").write_text(
+        '{"packages":["npm:pi-lens"]}\n',
+        encoding="utf-8",
+    )
+
+    materialize_native_login_state("pi", target_home, source_home=source_home)
+    first_settings = json.loads((target_home / "settings.json").read_text(encoding="utf-8"))
+    first_projected = Path(first_settings["packages"][0])
+
+    (npm_extension / "index.ts").write_text("patched without lock change\n", encoding="utf-8")
+    second_home = tmp_path / "second-managed-home"
+    materialize_native_login_state("pi", second_home, source_home=source_home)
+    second_settings = json.loads((second_home / "settings.json").read_text(encoding="utf-8"))
+    second_projected = Path(second_settings["packages"][0])
+
+    assert second_projected != first_projected
+    assert str(second_projected).startswith(str(tmp_path / "xdg-cache"))
+    assert second_projected.joinpath("index.ts").read_text(encoding="utf-8") == (
+        "patched without lock change\n"
+    )
 
 
 def test_native_pi_restart_repoints_to_updated_shared_snapshot(tmp_path: Path, monkeypatch) -> None:

--- a/test/test_projected_assets.py
+++ b/test/test_projected_assets.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 from pathlib import Path
 import shutil
+import threading
 
 import pytest
 
@@ -280,4 +282,188 @@ def test_seed_projected_file_rolls_back_when_marker_write_fails(
 
     assert not projected_assets.seed_projected_file(source, target, label=_LABEL)
     assert not target.exists()
+    assert not _marker_path(target).exists()
+
+
+def test_copy_projected_tree_to_cache_handles_concurrent_first_publish(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / 'source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    _write_tree(source, 'shared\n')
+    copy_barrier = threading.Barrier(2)
+    original_copytree = shutil.copytree
+
+    def synchronized_copytree(*args, **kwargs):
+        result = original_copytree(*args, **kwargs)
+        copy_barrier.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(projected_assets.shutil, 'copytree', synchronized_copytree)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda _: projected_assets.copy_projected_tree_to_cache(
+                    source,
+                    target,
+                    label=_LABEL,
+                ),
+                range(2),
+            )
+        )
+
+    assert results == [True, True]
+    assert (target / 'asset.txt').read_text(encoding='utf-8') == 'shared\n'
+    assert json.loads(_marker_path(target).read_text(encoding='utf-8'))['label'] == _LABEL
+    assert not list(target.parent.glob(f'.{target.name}.ccb-cache-*'))
+
+
+def test_copy_projected_tree_to_cache_records_explicit_marker_source(tmp_path: Path) -> None:
+    staged_source = tmp_path / 'staged-source'
+    authority_source = tmp_path / 'authority-source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    _write_tree(staged_source, 'normalized\n')
+    _write_tree(authority_source, 'original\n')
+
+    assert projected_assets.copy_projected_tree_to_cache(
+        staged_source,
+        target,
+        label=_LABEL,
+        marker_source=authority_source,
+    )
+
+    marker = json.loads(_marker_path(target).read_text(encoding='utf-8'))
+    assert marker['source'] == str(authority_source)
+    assert (target / 'asset.txt').read_text(encoding='utf-8') == 'normalized\n'
+
+
+def test_copy_projected_tree_to_cache_rejects_tampered_cache_hit(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    _write_tree(source, 'trusted\n')
+
+    assert projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    (target / 'asset.txt').write_text('tampered\n', encoding='utf-8')
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert (target / 'asset.txt').read_text(encoding='utf-8') == 'tampered\n'
+
+
+def test_tree_content_fingerprint_and_cache_track_executable_mode(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    _write_tree(source, 'script\n')
+    asset = source / 'asset.txt'
+    asset.chmod(0o644)
+    first_digest = projected_assets.tree_content_fingerprint(source)
+    first_target = tmp_path / 'cache' / first_digest / 'bundle'
+    assert projected_assets.copy_projected_tree_to_cache(source, first_target, label=_LABEL)
+
+    asset.chmod(0o755)
+    second_digest = projected_assets.tree_content_fingerprint(source)
+    second_target = tmp_path / 'cache' / second_digest / 'bundle'
+    assert second_digest != first_digest
+    assert projected_assets.copy_projected_tree_to_cache(source, second_target, label=_LABEL)
+    assert second_target.joinpath('asset.txt').stat().st_mode & 0o777 == 0o755
+
+
+def test_copy_projected_tree_to_cache_rejects_symlinked_cache_root(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    external = tmp_path / 'external'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    _write_tree(source, 'same\n')
+    _write_tree(external, 'same\n')
+    target.parent.mkdir(parents=True)
+    target.symlink_to(external, target_is_directory=True)
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert target.is_symlink()
+    assert not _marker_path(target).exists()
+
+
+def test_tree_content_fingerprint_tracks_root_directory_mode(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    _write_tree(source, 'same\n')
+    source.chmod(0o700)
+    first_digest = projected_assets.tree_content_fingerprint(source)
+
+    source.chmod(0o755)
+
+    assert projected_assets.tree_content_fingerprint(source) != first_digest
+
+
+def test_copy_projected_tree_to_cache_preserves_internal_directory_symlink(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    nested = source / 'nested'
+    _write_tree(nested, 'linked\n')
+    (source / 'alias').symlink_to('nested', target_is_directory=True)
+
+    assert projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert (target / 'alias').is_symlink()
+    assert (target / 'alias').readlink() == Path('nested')
+    assert (target / 'alias' / 'asset.txt').read_text(encoding='utf-8') == 'linked\n'
+
+
+def test_copy_projected_tree_to_cache_rejects_external_source_symlink(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    external = tmp_path / 'external'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    source.mkdir()
+    _write_tree(external, 'external\n')
+    (source / 'escape').symlink_to(external, target_is_directory=True)
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert not target.exists()
+
+
+def test_copy_projected_tree_to_cache_rejects_absolute_internal_symlink(tmp_path: Path) -> None:
+    source = tmp_path / 'source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    nested = source / 'nested'
+    _write_tree(nested, 'internal\n')
+    (source / 'absolute').symlink_to(nested, target_is_directory=True)
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert not target.exists()
+
+
+@pytest.mark.parametrize('link_target', ['missing', 'loop'])
+def test_copy_projected_tree_to_cache_rejects_unresolvable_internal_symlink(
+    tmp_path: Path,
+    link_target: str,
+) -> None:
+    source = tmp_path / 'source'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    source.mkdir()
+    (source / 'loop').symlink_to(link_target)
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert not target.exists()
+
+
+def test_copy_projected_tree_to_cache_rejects_symlinked_concurrent_winner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / 'source'
+    external = tmp_path / 'external'
+    target = tmp_path / 'cache' / 'digest' / 'bundle'
+    _write_tree(source, 'same\n')
+    _write_tree(external, 'same\n')
+    original_copytree = shutil.copytree
+
+    def copytree_with_symlinked_winner(*args, **kwargs):
+        result = original_copytree(*args, **kwargs)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(external, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(projected_assets.shutil, 'copytree', copytree_with_symlinked_winner)
+
+    assert not projected_assets.copy_projected_tree_to_cache(source, target, label=_LABEL)
+    assert target.is_symlink()
     assert not _marker_path(target).exists()

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -74,6 +74,15 @@ def _reset_detached_tmux_server_cache() -> None:
     tmux_panes._PREPARED_DETACHED_TMUX_SERVER_KEYS.clear()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_git_identity_lookup(monkeypatch) -> None:
+    """Keep provider process doubles scoped to runtime launches."""
+    monkeypatch.setattr(
+        'provider_core.caller_env.managed_git_identity_env',
+        lambda **_kwargs: {},
+    )
+
+
 def _spec(
     name: str,
     provider: str = 'codex',


### PR DESCRIPTION
## Summary

This is a follow-up bug fix for #328, which introduced shared Pi profile-asset snapshots. After #328 was merged, valid local Pi packages could be copied into CCB's isolated cache without the runtime dependency topology available in their source workspaces.

Observed production failures:

- `pi-accounts` could not resolve `proper-lockfile`, which npm had hoisted outside the copied package directory.
- `pi-antigravity` loaded `effect`, but `effect` could not resolve its pnpm-linked transitive dependency `fast-check` after snapshot isolation.

Both packages declared their dependencies correctly. The defect was in CCB snapshot materialization, and the same class could affect local, Git, or direct Pi package directories whose effective production dependency closure extends beyond the selected directory.

## Root cause and production fix

PR #328 copied package directories into a content-addressed cache as standalone trees. It preserved package files, but not dependencies resolved through npm workspace hoisting or pnpm store symlinks. Pi then loaded the isolated snapshot as the new authority, where Node resolution could no longer reach those dependencies.

This PR:

- normalizes package-style local, Git, and direct extension directories into a self-contained production dependency closure before publication;
- resolves declared dependencies through Node-style ancestor `node_modules` lookup, covering npm hoisting and pnpm-linked roots;
- preserves required, present optional, bundled, scoped, aliased, transitive, and circular dependency behavior;
- keeps Pi host-provided peer dependencies outside the copied closure;
- performs no network installation and runs no lifecycle scripts at managed-agent startup;
- fails before settings publication for missing or malformed required dependencies;
- verifies cache bytes and modes, source drift, safe internal relative symlinks, cache hits, staging copies, and concurrent publication winners;
- rejects absolute, dangling, cyclic, escaping, and late-substituted symlinks.

The shared projected-asset API used by Codex and Copilot remains compatible. Package normalization is limited to package-style Pi snapshot sources; npm-managed Pi packages continue to use the shared complete npm tree.

## CI failures observed after submission

The initial full Python matrix reported 17 failures. These failures were not caused by the Pi snapshot changes in this PR: the exact upstream base commit, `2dc46cf`, had already failed all four Python matrices before PR #334 ran.

### 1. Sixteen inherited launch-test failures from #330

PR #330 added managed Git identity lookup through `subprocess.run()`. Existing DSH and Codex runtime-launch tests replace `subprocess.Popen` with minimal provider-launch `Proc` / `FakePopen` doubles. Because Python exposes the shared `subprocess` module object, those doubles also intercepted the new Git identity lookup and did not implement the context-manager protocol required by `subprocess.run()`.

Commit `0ac4d155` repairs this test isolation by adding file-local autouse fixtures that stub `managed_git_identity_env` at the two direct-import call sites:

- `provider_backends.native_cli_support.execution.managed_git_identity_env`
- `provider_core.caller_env.managed_git_identity_env`

This keeps provider process doubles scoped to the launch behavior those files test. Production code is unchanged, and the dedicated Git identity tests remain unmodified and continue to exercise the real lookup behavior.

### 2. One inherited Windows isolation failure from #320

The remaining failure is the existing edge:

`lib/ccbd/app_runtime/service_graph.py -> platforms.windows.herdr.lifecycle_bridge`

It was introduced by PR #320 / commit `7a49d4ef` and is already present in the PR base. A tentative PR-side allowlist update could not affect the result because the `pull_request_target` workflow executes the trusted checker from the base revision. It also caused the cross-platform PR to be classified as a Windows change.

Commit `e7be4fbe` therefore removes that ineffective policy edit. PR #334 now has zero net Windows-policy diff. The remaining base failure must be repaired or explicitly accepted on upstream `main`; an ordinary fork PR cannot authorize its own trusted-base checker change.

## Combined-merge basis

PR #328's merged implementation commit is `d6f9383d` (merge `c0a742e3`). PR #334 is based on `2dc46cf`, which already contains that merged implementation. The older #328 candidate commit `168545c` has a different history, but no content difference from `d6f9383d` in the #328 production and test files.

At the current base, GitHub's synthetic PR merge tree is identical to PR HEAD. The verification below therefore exercises the combined state: merged #328 plus this follow-up fix and the later upstream changes already in `2dc46cf`.

## Verification

Production-fix coverage:

- Complete Pi/projected-asset/Codex/Copilot mechanism suite: **268 passed**
- Targeted scoped / missing-optional / bundled / circular-dependency selection: **4 passed**
- Real current Pi profile materialization followed by `PI_OFFLINE=1 pi --help`: exited 0 with no missing-module or extension-load error
- Python byte compilation: passed
- `git diff --check`: passed

Inherited CI-repair coverage on final HEAD `e7be4fbe`:

- Complete DSH, runtime-launch, and Git identity files: **164 passed**
- Windows isolation file: **11 passed, 1 inherited base failure**
- No third test module with the same `Proc` / `FakePopen` leakage pattern was found
- Provider blackbox, Rust helpers, lifecycle smoke, macOS install smoke, macOS real ccbd/ask smoke, and WSL mounted-drive ccbd/ask smoke pass on GitHub

## Independent review

Final follow-up range `bb148731..e7be4fbe`:

- CCB reviewer: **ACCEPT**, no blocker, major, or minor finding; independently passed 164/164 focused tests.
- Independent `GLM-5.3/high`: **ACCEPT**, no blocker, major, or minor finding.

Both reviewers confirmed that the two fixtures patch the correct caller-owned seams, do not mask dedicated Git identity behavior, and that the remaining Windows failure belongs to the upstream base rather than this PR.

## Commits

- `821bd540` — preserve Pi snapshot runtime dependencies
- `bb148731` — cover dependency-boundary cases and guard the Node probe
- `0ac4d155` — isolate inherited #330 launch-test doubles from Git identity lookup
- `e7be4fbe` — remove the ineffective PR-side Windows policy change

## Checklist

- [x] Built on the merged #328 implementation in upstream `main`
- [x] Pi regression and shared compatibility suites pass
- [x] Real offline Pi startup smoke passes
- [x] Inherited #330 launch-test failures are repaired without production changes
- [x] PR has no net Windows-policy change
- [x] Final follow-up range accepted by CCB reviewer
- [x] Final follow-up range accepted by `GLM-5.3/high`
- [ ] Upstream must repair or explicitly accept the pre-existing #320 Windows isolation edge

No global CCB installation, config reload, endpoint restart, or merge is performed by this PR.

Related: #328, #330, #320