### PR TITLE
fix(ci): allowlist service_graph herdr lifecycle import

### DIFF
--- a/platforms/windows/tools/check_pr_isolation.py
+++ b/platforms/windows/tools/check_pr_isolation.py
@@ -59,6 +59,7 @@ WINDOWS_SUBJECT_MARKER = re.compile(
 ALLOWED_SHARED_WINDOWS_IMPORTS = frozenset(
     {
         ("lib/agents/config_loader_runtime/parsing_runtime/topology.py", "platforms.windows.os_platform"),
+        ("lib/ccbd/app_runtime/service_graph.py", "platforms.windows.herdr.lifecycle_bridge"),
         ("lib/ccbd/control_plane_transport/factory.py", "platforms.windows.control_plane.tcp"),
         ("lib/ccbd/handlers/ping_runtime/payloads.py", "platforms.windows.herdr.ccbd_surface_projection"),
         ("lib/ccbd/project_view/service.py", "platforms.windows.herdr.ccbd_surface_projection"),


### PR DESCRIPTION
## Summary
- Add the existing `lib/ccbd/app_runtime/service_graph.py` → `platforms.windows.herdr.lifecycle_bridge` import to `ALLOWED_SHARED_WINDOWS_IMPORTS`.
- This import is already on `main`; without the allowlist entry, Windows PR isolation contract tests fail even when a PR does not expand shared→Windows coupling.

## Test plan
- [x] `python3 -m pytest test/test_windows_pr_isolation.py` → 12 passed
- [x] Confirmed the import is observed by `scan_shared_windows_imports` and covered by the updated allowlist