### PR TITLE
feat(config ui): 支持 Pi 本地模型选择

### DIFF
--- a/assets/config_ui/index.html
+++ b/assets/config_ui/index.html
@@ -1817,6 +1817,8 @@ model = "gpt-5.5"</pre>
         modelSourceSupported: "Model source: {source}. Supported thinking levels are written to the static agent overlay.",
         modelSourcePending: "Model source: {source}. Selection is visible for planning, but CCB cannot write this provider model shortcut yet.",
         modelShortcutUnavailable: "This provider has no CCB model shortcut. Use provider startup configuration only after validation support is defined.",
+        piModelSourceSupported: "Model source: Pi local models.",
+        piModelSourceEmpty: "No configured Pi models were found. An existing selection is preserved.",
         thinkingLevelsTitle: "Model supports: {levels}.",
         thinkingUnavailableTitle: "The selected provider or model has no writable static thinking mapping.",
         activationBlocked: "Activation blocked",
@@ -2090,6 +2092,8 @@ model = "gpt-5.5"</pre>
         modelSourceSupported: "模型来源：{source}。受支持的思考强度会写入静态 Agent overlay。",
         modelSourcePending: "模型来源：{source}。当前仅供规划选择，CCB 尚不能写入该 provider 的模型快捷设置。",
         modelShortcutUnavailable: "该 provider 没有 CCB 模型快捷设置；请等待启动配置的校验支持。",
+        piModelSourceSupported: "模型来源：Pi 本地模型配置。",
+        piModelSourceEmpty: "未找到已配置的 Pi 模型；已有选择会被保留。",
         thinkingLevelsTitle: "模型支持：{levels}。",
         thinkingUnavailableTitle: "当前 provider 或模型没有可写入的静态 thinking 映射。",
         activationBlocked: "禁止激活",
@@ -2238,7 +2242,8 @@ model = "gpt-5.5"</pre>
         ] },
         { id: "opencode", model_shortcut: true, model_source: "provider_catalog_required", custom_model: true, static_thinking: false, models: [] },
         { id: "mimo", model_shortcut: true, model_source: "custom_only", custom_model: true, static_thinking: false, models: [] },
-        ...["droid", "agy", "kimi", "qwen", "cursor", "copilot", "crush", "kiro", "pi", "zai", "grok"].map((id) => ({
+        { id: "pi", model_shortcut: true, model_source: "pi_models_json", custom_model: false, static_thinking: false, models: [] },
+        ...["droid", "agy", "kimi", "qwen", "cursor", "copilot", "crush", "kiro", "zai", "grok"].map((id) => ({
           id,
           model_shortcut: false,
           model_source: "none",
@@ -3153,7 +3158,7 @@ main = "demo:codex"
           <label class="field"><span class="label">${t("model")}</span><select class="select model-select" data-field="model" ${isRich || (!capability.model_shortcut && !models.length) ? "disabled" : ""}><option value="inherit">${t("inherit")}</option>${models.map((item) => `<option value="${escapeAttribute(item.id)}" ${item.id === model ? "selected" : ""}>${escapeHtml(item.label || item.id)}</option>`).join("")}${model !== "inherit" && !models.some((item) => item.id === model) ? `<option value="${escapeAttribute(model)}" selected>${escapeHtml(model)}</option>` : ""}${capability.custom_model ? `<option value="__custom__">${t("customModel")}</option>` : ""}</select></label>
           <label class="field"><span class="label">${t("thinking")}</span><select class="select thinking-select" data-field="thinking" data-current="${escapeAttribute(thinking)}" disabled><option value="inherit">${t("inherit")}</option></select></label>
         </div>
-        <p class="field-note model-capability-note">${capability.model_shortcut ? tf("modelSourceSupported", { source: capability.model_source || "catalog" }) : t("modelShortcutUnavailable")}</p>
+        <p class="field-note model-capability-note">${modelCapabilityNote(capability)}</p>
         <details class="api-details" ${overlay.key || overlay.url ? "open" : ""}>
           <summary>${t("apiOverride")}</summary>
           <div class="details-body api-grid">
@@ -3642,6 +3647,14 @@ main = "demo:codex"
       return providerCapabilities.providers.find((item) => item.id === providerId);
     }
 
+    function modelCapabilityNote(capability) {
+      if (!capability || !capability.model_shortcut) return t("modelShortcutUnavailable");
+      if (capability.id === "pi") {
+        return capability.models.length ? t("piModelSourceSupported") : t("piModelSourceEmpty");
+      }
+      return tf("modelSourceSupported", { source: capability.model_source || "catalog" });
+    }
+
     function option(value, label, selected = false) {
       const node = document.createElement("option");
       node.value = value;
@@ -3677,6 +3690,9 @@ main = "demo:codex"
         capability.models.forEach((model) => {
           modelSelect.append(option(model.id, model.label || model.id, model.id === previousModel));
         });
+        if (previousModel !== "inherit" && !capability.models.some((model) => model.id === previousModel)) {
+          modelSelect.append(option(previousModel, previousModel, true));
+        }
         if (capability.custom_model) {
           modelSelect.append(option("__custom__", t("customModel")));
         }
@@ -3685,7 +3701,7 @@ main = "demo:codex"
           ? previousModel
           : "inherit";
         if (note) note.textContent = capability.model_shortcut
-          ? tf("modelSourceSupported", { source: capability.model_source })
+          ? modelCapabilityNote(capability)
           : tf("modelSourcePending", { source: capability.model_source });
       } else {
         modelSelect.replaceChildren(option("inherit", t("unsupportedModelShortcut"), true));

--- a/docs/ccb-config-layout-contract.md
+++ b/docs/ccb-config-layout-contract.md
@@ -513,10 +513,14 @@ Contract:
   - `gemini`
   - `opencode`
   - `mimo`
+  - `pi`
   - `deepseek`
 - `model` is user-facing sugar only. Providers with model flags compile it onto
   the existing startup-argument path. DeepSeek compiles it to
   `DEEPCODE_MODEL`, the Deep Code CLI's documented runtime override.
+- Pi model values may use the qualified `provider/model` form from the source
+  user's `.pi/agent/models.json`; CCB passes the complete value through one
+  `--model` argument and does not generate a separate `--provider` argument.
 - `model` may coexist with unrelated `startup_args`, but must not be combined
   with provider model flags already present in `startup_args`.
 - Config rendering and recovery must preserve the user-facing `model` field

--- a/docs/features/pi-model-selection.md
+++ b/docs/features/pi-model-selection.md
@@ -1,0 +1,345 @@
+# Pi Model Selection in CCB Config UI
+
+## Feature Overview
+
+CCB Config UI supports model selection for a pane whose CCB provider is `pi`.
+Pi accepts qualified model selection with:
+
+```text
+pi --model <provider>/<model>
+```
+
+Pi also stores custom provider and model definitions in its local
+`models.json`. This feature exposes the safe subset of that catalog in the
+existing Config UI model selector, persists the selected qualified identifier
+in CCB's existing `model` field, and compiles it to Pi's `--model` startup flag.
+
+Status: implemented and verified.
+
+## Goals And Scope
+
+In scope:
+
+- Discover Pi models from the source user's effective Pi model catalog.
+- Display each item as the exact qualified identifier `provider/model`.
+- Save the identifier through the existing static agent `model` setting.
+- Compile Pi models to `--model provider/model` without `--provider`.
+- Preserve existing V2 and V3 config rendering and validation behavior.
+- Fail closed when the catalog is missing or malformed and never expose secrets.
+
+Out of scope:
+
+- Editing `models.json`, provider URLs, API keys, headers, or authentication.
+- Remote API probes or claims that a configured endpoint is currently healthy.
+- Adding a separate Pi-provider field to the CCB schema.
+- Deriving Pi `--thinking` from model metadata in the first delivery.
+- Changing Pi headless job execution, whose command currently does not consume
+  an `AgentSpec`; static CCB pane launch is the target of this feature.
+
+## Confirmed Upstream Contract
+
+The design was checked against local Pi `0.84.4` and current Pi documentation.
+Both state that `--model` accepts `provider/id`. Pi first interprets the prefix
+before `/` as a provider when it matches a registered provider, so a separate
+`--provider` argument is neither required nor desired for this feature.
+
+Pi's model configuration defaults to `<source-home>/.pi/agent/models.json`.
+CCB already copies this file into each managed Pi home when provider config
+inheritance is enabled and starts Pi with `PI_CODING_AGENT_DIR` pointing at that
+managed directory.
+
+## User Flow
+
+1. The user selects `pi` as the pane provider.
+2. The model selector remains enabled and contains `inherit` followed by the
+   qualified models discovered from Pi's catalog.
+3. Each option uses the same exact string for value and visible label, for
+   example `local/gemini-3.8-flash-high` or `pay/gpt-5.6-terra`.
+4. Choosing an option writes the qualified string to the pane's agent overlay.
+5. Preview and save render it as:
+
+   ```toml
+   [agents.<agent>]
+   model = "pay/gpt-5.6-terra"
+   ```
+
+6. On the normal CCB restart/apply path, the Pi pane starts with:
+
+   ```text
+   pi --model pay/gpt-5.6-terra
+   ```
+
+7. Choosing `inherit` removes the agent-local `model` override and leaves Pi to
+   resolve its configured default.
+
+## Catalog Discovery
+
+### Source resolution
+
+The Pi-specific catalog reader in `lib/cli/services/config_ui.py` uses this
+normal source:
+
+```text
+current_provider_source_home() / ".pi" / "agent" / "models.json"
+```
+
+It uses `current_provider_source_home()` rather than raw `HOME`, because CCB can
+run inside a managed environment where `HOME` points at an agent-specific
+private directory. For testability, the public capability builder accepts an
+optional explicit Pi models path, matching the existing Codex cache injection
+pattern.
+
+The implementation reads the source catalog only. Scanning managed agent homes
+would make stale per-agent snapshots compete with the source of truth and could
+combine different catalogs into one misleading list.
+
+### Parsing and normalization
+
+Expected input shape:
+
+```json
+{
+  "providers": {
+    "local": {
+      "models": [
+        { "id": "gemini-3.8-flash-high" }
+      ]
+    }
+  }
+}
+```
+
+Parsing rules:
+
+- The root must be an object and `providers` must be an object.
+- A provider key must trim to a non-empty string and must not contain `/`.
+- `models` must be an array; non-object entries are ignored.
+- A model `id` must trim to a non-empty string.
+- Emit only `{id, label, reasoning_levels, default_reasoning_level,
+  context_window_max_tokens}` using the existing capability model shape.
+- Set both `id` and `label` to `provider/model-id`.
+- Preserve provider insertion order and model array order.
+- Deduplicate by the final qualified identifier, keeping the first occurrence.
+- Do not reject `/` inside a model ID. Pi splits only the first slash, and some
+  upstream model IDs legitimately contain further slashes.
+- Do not infer static CCB thinking levels from Pi's `reasoning` boolean.
+
+Security rule: never copy arbitrary fields from `models.json`. In particular,
+`apiKey`, `baseUrl`, `headers`, command substitutions, and provider display
+metadata must not cross the `/api/capabilities` boundary. Error messages must
+not include file contents.
+
+### Failure behavior
+
+Missing, unreadable, malformed, or structurally invalid files produce an empty
+Pi model list. Capability generation and the rest of Config UI remain usable.
+The provider still reports model-shortcut support so an already configured
+qualified value can be preserved, but the UI does not invent catalog entries.
+
+The capability record for Pi becomes:
+
+```json
+{
+  "id": "pi",
+  "model_shortcut": true,
+  "api_shortcut": false,
+  "model_source": "pi_models_json",
+  "models": [
+    {
+      "id": "local/gemini-3.8-flash-high",
+      "label": "local/gemini-3.8-flash-high",
+      "reasoning_levels": [],
+      "default_reasoning_level": null,
+      "context_window_max_tokens": null
+    }
+  ],
+  "custom_model": false,
+  "static_thinking": false
+}
+```
+
+No capability schema-version bump is required because this uses existing fields
+with existing meanings.
+
+## Frontend Interaction And State
+
+The existing model `<select>` is retained. This is a configuration tool, so a
+dense native selector is preferable to a new modal or custom picker.
+
+- Online catalog available: show `inherit` followed by all discovered qualified
+  models. Pi does not show the generic `Custom model...` option.
+- Empty/unavailable catalog: show only `inherit` and a concise note that no
+  configured Pi models were found. Keep the selector enabled so an existing
+  value can be retained, but offer no new model choice.
+- Existing value missing from the current catalog: preserve it as a selected
+  option. Do not silently reset it to `inherit` when capabilities refresh.
+- Provider change away from Pi: retain the current existing behavior that
+  clears model and thinking overlays to avoid cross-provider inheritance.
+- Thinking selector: remains disabled for Pi in this delivery.
+- Fallback/offline page data: mark Pi as model-shortcut capable with an empty
+  catalog and custom entry disabled. The static HTML must not embed
+  machine-local model names.
+
+The source note uses a localized, user-facing "Pi local models" label rather
+than exposing an internal token or absolute path. Empty text remains adjacent
+to the field and is accessible as normal text; color alone does not convey
+state.
+
+## Startup And Validation Design
+
+Pi is registered in the shared maps in `lib/provider_model_shortcuts.py`:
+
+```python
+_PROVIDER_MODEL_FLAGS["pi"] = ("--model",)
+_PROVIDER_MODEL_STARTUP_FLAGS["pi"] = "--model"
+```
+
+This single shared registration intentionally drives all existing contracts:
+
+- `supported_provider_model_shortcuts()` marks Pi as writable.
+- `AgentSpec` compiles `model` into `("--model", qualified_id)`.
+- duplicate `--model` in explicit `startup_args` is rejected.
+- V3 workflow/default validation uses the same compiler.
+- config rendering strips the generated args and preserves the structured
+  `model` field.
+- `provider_backends/pi/launcher.py` already appends `spec.startup_args`, so no
+  Pi-launcher special case is needed.
+
+The model string is treated as an opaque non-empty value by the shared compiler.
+The Pi dropdown emits only qualified values from the catalog. Manually authored
+TOML remains compatible and is ultimately validated by Pi at startup; Config UI
+does not add an arbitrary model-entry path for Pi.
+
+## Data And Persistence
+
+There is no new persisted field or migration. The only stored value is:
+
+```toml
+[agents.agent_name]
+model = "provider/model-id"
+```
+
+The Pi provider prefix belongs inside this string. CCB must not split it into a
+new field, and must not persist the generated `--model` arguments.
+
+The value may contain `/`, `:`, dots, or hyphens because it is TOML string data
+and Pi owns model-pattern interpretation. CCB's existing TOML serializer handles
+escaping.
+
+## Compatibility And Cross-Surface Impact
+
+Adding Pi to the shared shortcut set also changes project/mobile provider
+capability records from unsupported to `restart_required`. This matches the
+common capability contract and is covered by shared-contract assertions.
+
+The mobile gateway reuses Config UI catalogs and receives the same sanitized Pi
+model list without a new endpoint. This is a compatible consequence and does
+not require a mobile UI redesign.
+
+Existing configs using explicit Pi `startup_args = ["--model", "..."]` remain
+valid when no structured `model` is present. Combining both forms becomes a
+visible validation error, matching Codex, Claude, Gemini, and OpenCode.
+
+## Verification Coverage
+
+### Catalog and security tests
+
+`test/test_config_ui.py` covers:
+
+- multiple providers and models become ordered `provider/model` rows;
+- duplicate qualified IDs keep the first entry;
+- model IDs containing an additional slash are preserved;
+- empty providers, missing files, malformed JSON, and wrong field types yield
+  an empty list without failing the capability response;
+- payload serialization contains no API key, URL, header, or source path;
+- Pi advertises `model_shortcut = true`, `custom_model = false`,
+  `static_thinking = false`, and `model_source = "pi_models_json"`;
+- the embedded fallback capability marks Pi writable but embeds no local models.
+
+### Config compiler and rendering tests
+
+`test/test_v2_config_loader.py` and the shared V3 cases prove:
+
+- `model = "pay/gpt-5.6-terra"` compiles to
+  `("--model", "pay/gpt-5.6-terra")`;
+- unrelated startup arguments follow the generated model prefix;
+- structured model plus explicit `--model` is rejected;
+- rendered TOML retains the qualified `model` and omits generated startup args.
+
+### Pi launch test
+
+A focused case beside the existing native Pi launcher tests in
+`test/test_v2_runtime_launch.py` proves the quoted command contains:
+
+```text
+pi --model pay/gpt-5.6-terra
+```
+
+and does not contain `--provider`.
+
+### Acceptance check
+
+Acceptance used a temporary source home with a non-secret fixture catalog to
+start Config UI, select Pi and a qualified model, render the draft, and verify
+the saved config. The launch test builds the Pi start command with a stub
+`PI_START_CMD`; the automated suite does not call a live model API.
+
+## Delivered Slices
+
+1. Shared launch contract: register Pi's `--model` shortcut and add compiler,
+   conflict, round-trip, and launch tests.
+2. Safe discovery: add the Pi catalog reader and capability payload tests.
+3. UI states: update fallback capability and localized source/empty messaging;
+   verify current selections survive empty/changed catalogs.
+4. Contract documentation: `docs/ccb-config-layout-contract.md` lists Pi as a
+   supported mapping, and this document records the delivered behavior and
+   verification results.
+
+## Acceptance Criteria
+
+- Selecting `pi` no longer shows the unsupported-shortcut message.
+- The dropdown shows exactly the qualified models from the effective source
+  `models.json`, including `local/gemini-3.8-flash-high` and
+  `pay/gpt-5.6-terra` for the reported local fixture.
+- Saving persists the exact qualified identifier in `model`.
+- Normal Pi pane launch receives exactly one `--model <qualified-id>` pair and
+  no generated `--provider` flag.
+- Invalid/unavailable catalogs do not break Config UI or erase an existing
+  configured model.
+- `/api/capabilities` exposes no Pi credentials, endpoints, headers, or paths.
+- Existing non-Pi model behavior and focused regression suites remain green.
+
+## Verification Status
+
+- Design discovery: complete.
+- Local Pi CLI contract: verified against version `0.84.4`.
+- Current upstream documentation: verified through Context7 and installed docs.
+- Implementation: complete in the shared model-shortcut compiler, Config UI
+  capability service, and browser model-selector state.
+- Catalog acceptance: the effective local catalog exposes the expected five
+  qualified IDs: `pay/gpt-5.6-sol`, `pay/gpt-5.6-terra`,
+  `pay/gpt-5.6-luna`, `pay/gpt-image-2`, and
+  `local/gemini-3.8-flash-high`.
+- Automated and shared-contract verification: `python3 -m pytest -q
+  test/test_config_ui.py test/test_v2_config_loader.py
+  test/test_v2_runtime_launch.py test/test_mobile_gateway_service.py
+  test/test_v3_config_loader.py test/test_provider_control_settings.py` passes
+  with 486 tests.
+- Static verification: `python3 -m py_compile` for all modified Python source
+  and test files, plus `git diff --check`, passes.
+
+## Known Limitations And Follow-Ups
+
+- An agent with `provider_profile.inherit_config = false` will not receive the
+  source `models.json`; a globally discovered custom model may therefore fail
+  when that isolated agent starts. Agent-profile-aware catalog filtering or a
+  save-time warning can be added later.
+- The catalog proves local configuration, not provider authentication or remote
+  endpoint availability. Pi remains the runtime authority and reports launch
+  errors normally.
+- Pi supports thinking suffixes and `--thinking`, but mapping CCB's thinking
+  selector to Pi is intentionally deferred until its precedence and
+  round-trip behavior are designed separately.
+- Headless Pi execution currently builds a job command without agent model
+  policy. Propagating static model selection into that path requires a separate
+  execution-contract change.

--- a/lib/cli/services/config_ui.py
+++ b/lib/cli/services/config_ui.py
@@ -42,6 +42,7 @@ from cli.services.theme import set_theme_preference, theme_preference_payload
 from platforms.windows.herdr.ccbd_surface_projection import herdr_surface_projection_passes_gate
 from ccbd.services.project_namespace_state import ProjectNamespaceStateStore
 from provider_core.registry import CORE_PROVIDER_NAMES, OPTIONAL_PROVIDER_NAMES
+from provider_core.source_home import current_provider_source_home
 from provider_model_shortcuts import supported_provider_model_shortcuts
 from provider_profiles import supported_provider_api_shortcuts, validate_provider_runtime_home_uniqueness
 from provider_thinking_shortcuts import provider_thinking_levels
@@ -364,6 +365,7 @@ def config_ui_provider_capabilities(
     environ: dict[str, str] | None = None,
     project_root: Path | None = None,
     codex_models_path: Path | None = None,
+    pi_models_path: Path | None = None,
     cli_models: dict[str, list[str]] | None = None,
     roles: tuple[dict[str, object], ...] | list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
@@ -374,6 +376,10 @@ def config_ui_provider_capabilities(
         env,
         project_root=project_root,
         explicit_path=codex_models_path,
+    )
+    pi_models = _pi_models(
+        explicit_path=pi_models_path,
+        source_home=_pi_models_source_home(env, use_process_identity=environ is None),
     )
     discovered_cli_models = (
         {
@@ -466,6 +472,7 @@ def config_ui_provider_capabilities(
         ],
         'opencode': [_model(model_id, model_id) for model_id in discovered_cli_models.get('opencode', [])],
         'mimo': [_model(model_id, model_id) for model_id in discovered_cli_models.get('mimo', [])],
+        'pi': pi_models,
     }
     providers = []
     for provider in (*CORE_PROVIDER_NAMES, *OPTIONAL_PROVIDER_NAMES):
@@ -485,6 +492,8 @@ def config_ui_provider_capabilities(
             source = 'deepseek_v4_and_deepcode_contract'
         elif provider == 'dsh':
             source = 'deepseek_harness_official_catalog'
+        elif provider == 'pi':
+            source = 'pi_models_json'
         providers.append(
             {
                 'id': provider,
@@ -492,7 +501,7 @@ def config_ui_provider_capabilities(
                 'api_shortcut': provider in api_supported,
                 'model_source': source,
                 'models': suggestions.get(provider, []),
-                'custom_model': model_shortcut,
+                'custom_model': model_shortcut and provider != 'pi',
                 'static_thinking': bool(provider_thinking_levels(provider)),
             }
         )
@@ -603,6 +612,76 @@ def _codex_models(
         ),
         _model('gpt-5.5', 'GPT-5.5', reasoning_levels=['low', 'medium', 'high', 'xhigh']),
     ], 'ccb_catalog_fallback'
+
+
+def _source_home_from_capability_environ(environ: dict[str, str]) -> Path | None:
+    for name in ('CCB_SOURCE_HOME', 'HOME'):
+        raw = str(environ.get(name) or '').strip()
+        if raw:
+            return Path(raw).expanduser()
+    return None
+
+
+def _pi_models_source_home(
+    environ: dict[str, str],
+    *,
+    use_process_identity: bool,
+) -> Path | None:
+    if not use_process_identity:
+        return _source_home_from_capability_environ(environ)
+    try:
+        return current_provider_source_home()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _pi_models(
+    *,
+    explicit_path: Path | None,
+    source_home: Path | None,
+) -> list[dict[str, object]]:
+    path = (
+        Path(explicit_path).expanduser()
+        if explicit_path is not None
+        else Path(source_home).expanduser() / '.pi' / 'agent' / 'models.json'
+        if source_home is not None
+        else None
+    )
+    if path is None:
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, ValueError, TypeError):
+        return []
+    providers = payload.get('providers') if isinstance(payload, dict) else None
+    if not isinstance(providers, dict):
+        return []
+    rows: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for raw_provider, provider_payload in providers.items():
+        if not isinstance(raw_provider, str):
+            continue
+        provider = raw_provider.strip()
+        if not provider or '/' in provider or not isinstance(provider_payload, dict):
+            continue
+        models = provider_payload.get('models')
+        if not isinstance(models, list):
+            continue
+        for item in models:
+            if not isinstance(item, dict):
+                continue
+            raw_model_id = item.get('id')
+            if not isinstance(raw_model_id, str):
+                continue
+            model_id = raw_model_id.strip()
+            if not model_id:
+                continue
+            qualified_id = f'{provider}/{model_id}'
+            if qualified_id in seen:
+                continue
+            seen.add(qualified_id)
+            rows.append(_model(qualified_id, qualified_id))
+    return rows
 
 
 def _codex_models_cache_paths(

--- a/lib/provider_model_shortcuts.py
+++ b/lib/provider_model_shortcuts.py
@@ -6,6 +6,7 @@ _PROVIDER_MODEL_FLAGS = {
     'gemini': ('-m', '--model'),
     'opencode': ('-m', '--model'),
     'mimo': ('--model',),
+    'pi': ('--model',),
 }
 
 _PROVIDER_MODEL_STARTUP_FLAGS = {
@@ -14,6 +15,7 @@ _PROVIDER_MODEL_STARTUP_FLAGS = {
     'gemini': '-m',
     'opencode': '-m',
     'mimo': '--model',
+    'pi': '--model',
 }
 
 _PROVIDER_MODEL_RUNTIME_ENV = {

--- a/test/test_config_ui.py
+++ b/test/test_config_ui.py
@@ -58,6 +58,9 @@ def test_config_ui_asset_is_packaged_source_content() -> None:
     assert 'function scanAgentHistory()' in page
     assert 'function cleanupAgentHistory()' in page
     assert '/api/storage/history' in page
+    assert '{ id: "pi", model_shortcut: true, model_source: "pi_models_json", custom_model: false' in page
+    assert 'piModelSourceSupported: "模型来源：Pi 本地模型配置。"' in page
+    assert 'piModelSourceEmpty: "未找到已配置的 Pi 模型；已有选择会被保留。"' in page
     assert 'id="config-editor-section"' in page
     assert 'id="agent-session-storage"' in page
     assert 'id="observe-section"' not in page
@@ -1469,10 +1472,40 @@ def test_config_ui_provider_capabilities_use_current_safe_model_sources(tmp_path
         ),
         encoding='utf-8',
     )
+    pi_models_path = tmp_path / 'pi-models.json'
+    pi_models_path.write_text(
+        json.dumps(
+            {
+                'providers': {
+                    'pay': {
+                        'apiKey': 'secret-pay-key',
+                        'baseUrl': 'https://secret-pay.example.test/v1',
+                        'headers': {'Authorization': 'secret-header'},
+                        'models': [
+                            {'id': 'gpt-5.6-terra', 'name': 'Terra', 'apiKey': 'model-secret'},
+                            {'id': 'gpt-5.6-terra'},
+                            {'id': 'openai/gpt-5.6-sol'},
+                            {'id': 56},
+                            {'name': 'missing-id'},
+                        ],
+                    },
+                    'local': {
+                        'models': [{'id': 'gemini-3.8-flash-high'}],
+                    },
+                    'invalid/provider': {
+                        'models': [{'id': 'must-not-appear'}],
+                    },
+                    'wrong-models': {'models': {'id': 'not-an-array'}},
+                }
+            }
+        ),
+        encoding='utf-8',
+    )
 
     payload = config_ui_provider_capabilities(
         environ={'HOME': str(tmp_path), 'PATH': ''},
         codex_models_path=cache_path,
+        pi_models_path=pi_models_path,
         cli_models={
             'opencode': ['openai/gpt-5.6-sol'],
             'mimo': ['xiaomi/mimo-v2.5-pro'],
@@ -1521,6 +1554,25 @@ def test_config_ui_provider_capabilities_use_current_safe_model_sources(tmp_path
     assert providers['dsh']['model_source'] == 'deepseek_harness_official_catalog'
     assert [model['id'] for model in providers['opencode']['models']] == ['openai/gpt-5.6-sol']
     assert [model['id'] for model in providers['mimo']['models']] == ['xiaomi/mimo-v2.5-pro']
+    assert [model['id'] for model in providers['pi']['models']] == [
+        'pay/gpt-5.6-terra',
+        'pay/openai/gpt-5.6-sol',
+        'local/gemini-3.8-flash-high',
+    ]
+    assert [model['label'] for model in providers['pi']['models']] == [
+        'pay/gpt-5.6-terra',
+        'pay/openai/gpt-5.6-sol',
+        'local/gemini-3.8-flash-high',
+    ]
+    assert providers['pi']['model_shortcut'] is True
+    assert providers['pi']['custom_model'] is False
+    assert providers['pi']['static_thinking'] is False
+    assert providers['pi']['model_source'] == 'pi_models_json'
+    serialized_pi = json.dumps(providers['pi'])
+    assert 'secret-pay-key' not in serialized_pi
+    assert 'secret-pay.example.test' not in serialized_pi
+    assert 'secret-header' not in serialized_pi
+    assert 'model-secret' not in serialized_pi
     assert providers['codex']['static_thinking'] is True
     assert providers['claude']['static_thinking'] is True
     assert providers['deepseek']['static_thinking'] is True
@@ -1529,6 +1581,74 @@ def test_config_ui_provider_capabilities_use_current_safe_model_sources(tmp_path
         for name, provider in providers.items()
         if name not in {'codex', 'claude', 'deepseek', 'dsh'}
     )
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        '{not-json',
+        '[]',
+        '{}',
+        '{"providers": []}',
+    ],
+)
+def test_config_ui_pi_model_catalog_fails_closed(tmp_path: Path, payload: str) -> None:
+    pi_models_path = tmp_path / 'models.json'
+    pi_models_path.write_text(payload, encoding='utf-8')
+
+    capabilities = config_ui_provider_capabilities(
+        environ={'HOME': str(tmp_path), 'PATH': ''},
+        pi_models_path=pi_models_path,
+        cli_models={'opencode': [], 'mimo': []},
+        roles=(),
+    )
+    pi = next(provider for provider in capabilities['providers'] if provider['id'] == 'pi')
+
+    assert pi['model_shortcut'] is True
+    assert pi['custom_model'] is False
+    assert pi['models'] == []
+
+
+def test_config_ui_pi_model_catalog_missing_file_fails_closed(tmp_path: Path) -> None:
+    capabilities = config_ui_provider_capabilities(
+        environ={'HOME': str(tmp_path), 'PATH': ''},
+        pi_models_path=tmp_path / 'missing-models.json',
+        cli_models={'opencode': [], 'mimo': []},
+        roles=(),
+    )
+    pi = next(provider for provider in capabilities['providers'] if provider['id'] == 'pi')
+
+    assert pi['models'] == []
+
+
+def test_config_ui_pi_model_catalog_uses_source_home_before_home(tmp_path: Path) -> None:
+    source_home = tmp_path / 'source-home'
+    fallback_home = tmp_path / 'fallback-home'
+    source_models_path = source_home / '.pi' / 'agent' / 'models.json'
+    fallback_models_path = fallback_home / '.pi' / 'agent' / 'models.json'
+    source_models_path.parent.mkdir(parents=True)
+    fallback_models_path.parent.mkdir(parents=True)
+    source_models_path.write_text(
+        '{"providers":{"pay":{"models":[{"id":"gpt-5.6-terra"}]}}}',
+        encoding='utf-8',
+    )
+    fallback_models_path.write_text(
+        '{"providers":{"local":{"models":[{"id":"wrong-home-model"}]}}}',
+        encoding='utf-8',
+    )
+
+    capabilities = config_ui_provider_capabilities(
+        environ={
+            'CCB_SOURCE_HOME': str(source_home),
+            'HOME': str(fallback_home),
+            'PATH': '',
+        },
+        cli_models={'opencode': [], 'mimo': []},
+        roles=(),
+    )
+    pi = next(provider for provider in capabilities['providers'] if provider['id'] == 'pi')
+
+    assert [model['id'] for model in pi['models']] == ['pay/gpt-5.6-terra']
 
 
 def test_config_ui_codex_fallback_keeps_current_56_family_and_55(tmp_path: Path) -> None:

--- a/test/test_v2_config_loader.py
+++ b/test/test_v2_config_loader.py
@@ -1217,6 +1217,7 @@ url = "https://api.example.test/v1"
         ('claude', 'opus', ('--model', 'opus')),
         ('gemini', 'gemini-2.5-pro', ('-m', 'gemini-2.5-pro')),
         ('opencode', 'openai/gpt-5', ('-m', 'openai/gpt-5')),
+        ('pi', 'pay/gpt-5.6-terra', ('--model', 'pay/gpt-5.6-terra')),
         ('dsh', 'deepseek-v4-flash', ()),
     ],
 )
@@ -1262,6 +1263,24 @@ startup_args = ["--search"]
 
     assert spec.model == 'gpt-5'
     assert spec.startup_args == ('-m', 'gpt-5', '--search')
+
+
+def test_load_project_config_supports_pi_model_shortcut_with_extra_startup_args(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-pi-model-extra-startup-args'
+    _write(
+        project_root / '.ccb' / 'ccb.config',
+        '''cmd; agent1:pi
+
+[agents.agent1]
+model = "local/gemini-3.8-flash-high"
+startup_args = ["--offline"]
+''',
+    )
+
+    spec = load_project_config(project_root).config.agents['agent1']
+
+    assert spec.model == 'local/gemini-3.8-flash-high'
+    assert spec.startup_args == ('--model', 'local/gemini-3.8-flash-high', '--offline')
 
 
 @pytest.mark.parametrize(
@@ -1382,6 +1401,23 @@ def test_load_project_config_rejects_agent_model_shortcut_mixed_with_startup_arg
 [agents.agent1]
 model = "gpt-5"
 startup_args = ["--model", "gpt-4.1"]
+""",
+    )
+
+    with pytest.raises(ConfigValidationError, match='model cannot be combined with startup_args model flags'):
+        load_project_config(project_root)
+
+
+def test_load_project_config_rejects_pi_model_shortcut_mixed_with_startup_arg_model_flag(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-pi-model-startup-conflict'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    _write(
+        config_path,
+        """cmd; agent1:pi
+
+[agents.agent1]
+model = "pay/gpt-5.6-terra"
+startup_args = ["--model", "local/gemini-3.8-flash-high"]
 """,
     )
 
@@ -2562,6 +2598,32 @@ url = "https://api.example.test/v1"
     assert spec.model == 'gpt-5'
     assert spec.startup_args == ('-m', 'gpt-5', '--search')
     assert spec.api == AgentApiSpec(key='sk-test', url='https://api.example.test/v1')
+
+
+def test_render_project_config_text_round_trips_pi_model_shortcut(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-render-pi-model'
+    _write(
+        project_root / '.ccb' / 'ccb.config',
+        '''cmd; agent1:pi
+
+[agents.agent1]
+model = "pay/gpt-5.6-terra"
+startup_args = ["--offline"]
+''',
+    )
+
+    rendered = render_project_config_text(load_project_config(project_root).config)
+
+    assert 'model = "pay/gpt-5.6-terra"' in rendered
+    assert 'startup_args = ["--offline"]' in rendered
+    assert 'startup_args = ["--model", "pay/gpt-5.6-terra"' not in rendered
+
+    rewritten = tmp_path / 'repo-render-pi-model-roundtrip'
+    _write(rewritten / '.ccb' / 'ccb.config', rendered)
+    spec = load_project_config(rewritten).config.agents['agent1']
+
+    assert spec.model == 'pay/gpt-5.6-terra'
+    assert spec.startup_args == ('--model', 'pay/gpt-5.6-terra', '--offline')
 
 
 @pytest.mark.parametrize(

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -88,6 +88,7 @@ def _spec(
     provider: str = 'codex',
     *,
     startup_args: tuple[str, ...] = (),
+    model: str | None = None,
     provider_command_template: str | None = None,
     restore_default: RestoreMode = RestoreMode.AUTO,
 ) -> AgentSpec:
@@ -102,6 +103,7 @@ def _spec(
         permission_default=PermissionMode.MANUAL,
         queue_policy=QueuePolicy.SERIAL_PER_AGENT,
         provider_command_template=provider_command_template,
+        model=model,
         startup_args=startup_args,
     )
 
@@ -2392,6 +2394,50 @@ def test_native_cli_launcher_builds_provider_state_payload(
         assert (state_dir / 'home' / 'skills' / 'ccb-clear' / 'SKILL.md').is_file()
     else:
         assert visible_parts == [default_executable, '--demo']
+
+
+def test_pi_launcher_includes_qualified_agent_model_without_provider_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_home = tmp_path / 'source-home'
+    source_agent = source_home / '.pi' / 'agent'
+    source_agent.mkdir(parents=True)
+    (source_agent / 'models.json').write_text(
+        '{"providers":{"pay":{"models":[{"id":"gpt-5.6-terra"}]}}}\n',
+        encoding='utf-8',
+    )
+    monkeypatch.setenv('CCB_SOURCE_HOME', str(source_home))
+    monkeypatch.setenv('PI_START_CMD', '/tmp/stub-pi')
+    project_root = tmp_path / 'repo-pi-model-launcher'
+    (project_root / '.ccb').mkdir(parents=True)
+    command = ParsedStartCommand(
+        project=None,
+        agent_names=('pi1',),
+        restore=False,
+        auto_permission=False,
+    )
+    ctx = _context(project_root, command)
+    spec = _spec('pi1', provider='pi', model='pay/gpt-5.6-terra')
+    plan = WorkspacePlanner().plan(spec, ctx.project)
+    plan.workspace_path.mkdir(parents=True, exist_ok=True)
+    runtime_dir = ctx.paths.agent_provider_runtime_dir('pi1', 'pi')
+    launcher = build_default_runtime_launcher_map(include_optional=True)['pi']
+
+    prepared = launcher.prepare_launch_context(ctx, spec, plan, runtime_dir, {})
+    start_cmd = launcher.build_start_cmd(
+        command,
+        spec,
+        runtime_dir,
+        'sess-pi-model',
+        prepared_state=prepared,
+    )
+    visible_parts = shlex.split(start_cmd.rsplit('; ', 1)[-1])
+
+    assert visible_parts.count('--model') == 1
+    model_index = visible_parts.index('--model')
+    assert visible_parts[model_index + 1] == 'pay/gpt-5.6-terra'
+    assert '--provider' not in visible_parts
 
 
 def test_qoder_launcher_respects_explicit_config_and_permission_options(


### PR DESCRIPTION
## Summary

- 从源用户 `.pi/agent/models.json` 读取并脱敏输出完整限定的 `provider/model` 模型列表
- 在 Config UI 中为 Pi 启用模型下拉选择，并保留暂时不在目录中的既有模型配置
- 将 Pi 的结构化 `model` 配置编译为单一 `--model <provider/model>` 启动参数，不生成 `--provider`
- 补充模型目录、安全字段、配置冲突、TOML 往返和真实 launcher 命令测试

## Testing

- `python3 -m pytest -q test/test_config_ui.py test/test_v2_config_loader.py test/test_v2_runtime_launch.py test/test_mobile_gateway_service.py test/test_v3_config_loader.py test/test_provider_control_settings.py`
- 结果：`486 passed`
- `git diff --check origin/main...HEAD`
- 本机 Config UI 手工验收通过

## Notes

- Pi thinking 映射、headless job 模型传播和 `inherit_config = false` 的目录隔离不在本次范围内。