### PR TITLE
feat(config ui): 支持 Codex Astra 与 Pi 思考强度配置

### DIFF
--- a/assets/config_ui/index.html
+++ b/assets/config_ui/index.html
@@ -2214,6 +2214,7 @@ model = "gpt-5.5"</pre>
           custom_model: true,
           static_thinking: true,
           models: [
+            { id: "gpt-6-astra", label: "GPT-6 Astra", reasoning_levels: ["low", "medium", "high", "xhigh", "max"], default_reasoning_level: "low" },
             { id: "gpt-5.6-sol", label: "GPT-5.6 SOL", reasoning_levels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
             { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", reasoning_levels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
             { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", reasoning_levels: ["low", "medium", "high", "xhigh", "max"] },
@@ -2242,7 +2243,7 @@ model = "gpt-5.5"</pre>
         ] },
         { id: "opencode", model_shortcut: true, model_source: "provider_catalog_required", custom_model: true, static_thinking: false, models: [] },
         { id: "mimo", model_shortcut: true, model_source: "custom_only", custom_model: true, static_thinking: false, models: [] },
-        { id: "pi", model_shortcut: true, model_source: "pi_models_json", custom_model: false, static_thinking: false, models: [] },
+        { id: "pi", model_shortcut: true, model_source: "pi_models_json", custom_model: false, static_thinking: true, models: [] },
         ...["droid", "agy", "kimi", "qwen", "cursor", "copilot", "crush", "kiro", "zai", "grok"].map((id) => ({
           id,
           model_shortcut: false,

--- a/docs/ccb-config-layout-contract.md
+++ b/docs/ccb-config-layout-contract.md
@@ -544,13 +544,20 @@ Contract:
   offering model-specific levels; manual inherited-model use remains valid.
 - Codex accepts the model-specific level exposed by the installed Codex model
   catalog and compiles it to `-c model_reasoning_effort="<level>"`.
+  Astra's supported UI order is `low`, `medium`, `high`, `xhigh`, `max`;
+  the fallback catalog includes Astra when no usable cache is available.
+- Pi compiles `thinking` to `--thinking <level>` using the shared shortcut
+  compiler. Model-specific choices come from `reasoning` and
+  `thinkingLevelMap` in the source user's `.pi/agent/models.json`. Explicit
+  mappings are required for `xhigh` and `max`; `null` disables a level.
 - DeepSeek V4 Pro and V4 Flash accept `off`, `high`, or `max`. CCB compiles
   these to the Deep Code CLI's `DEEPCODE_THINKING_ENABLED` and
   `DEEPCODE_REASONING_EFFORT` environment overrides.
 - Other providers do not have a static CCB thinking mapping. Their `thinking`
   field must fail validation instead of being ignored.
 - Structured `thinking` must not be combined with an equivalent Codex
-  `startup_args` config override or Deep Code environment override.
+  `startup_args` config override, Pi `--thinking` startup override, or Deep Code
+  environment override.
 - Config rendering preserves `thinking` and removes generated provider launch
   arguments from user-facing TOML.
 

--- a/docs/features/pi-model-selection.md
+++ b/docs/features/pi-model-selection.md
@@ -14,7 +14,30 @@ Pi also stores custom provider and model definitions in its local
 existing Config UI model selector, persists the selected qualified identifier
 in CCB's existing `model` field, and compiles it to Pi's `--model` startup flag.
 
-Status: implemented and verified.
+Status: model selection and Codex/Pi thinking support are implemented and
+verified.
+
+## Codex And Pi Thinking Extension
+
+The extension is limited to Codex and Pi. Astra (`gpt-6-astra`, qualified with
+the configured provider for Pi) must expose `low`, `medium`, `high`, `xhigh`,
+and `max` in that order. Other providers retain their existing behavior.
+
+- Codex accepts Astra cache entries and retains cache-first discovery. Its
+  backend and frontend fallbacks include Astra with the known five-level
+  catalog. A usable cache is never supplemented with invented entries.
+- Pi reads model-specific `reasoning` and `thinkingLevelMap` metadata and
+  compiles the existing `thinking` field to `--thinking <level>`.
+- Pi's custom Astra entry requires an explicit mapping for `xhigh` and `max`;
+  Pi 0.84.4 otherwise clamps these levels to `high`. No managed runtime is
+  restarted by this configuration/code change.
+- Existing Codex cache metadata stays authoritative: Astra levels are ordered
+  and limited to the five supported values, without expanding a restricted
+  cache entry. Other Codex models retain their existing levels, including
+  `ultra` where configured. Cache discovery and service caching are unchanged.
+- Verification covers catalogs, parameter validation, TOML round trips, the
+  Pi launch command, and the Config UI selector. Actual API requests are
+  outside this verification scope.
 
 ## Goals And Scope
 
@@ -24,6 +47,8 @@ In scope:
 - Display each item as the exact qualified identifier `provider/model`.
 - Save the identifier through the existing static agent `model` setting.
 - Compile Pi models to `--model provider/model` without `--provider`.
+- Read Pi thinking capabilities and compile the existing `thinking` field to
+  `--thinking <level>` through the shared shortcut module.
 - Preserve existing V2 and V3 config rendering and validation behavior.
 - Fail closed when the catalog is missing or malformed and never expose secrets.
 
@@ -32,7 +57,6 @@ Out of scope:
 - Editing `models.json`, provider URLs, API keys, headers, or authentication.
 - Remote API probes or claims that a configured endpoint is currently healthy.
 - Adding a separate Pi-provider field to the CCB schema.
-- Deriving Pi `--thinking` from model metadata in the first delivery.
 - Changing Pi headless job execution, whose command currently does not consume
   an `AgentSpec`; static CCB pane launch is the target of this feature.
 
@@ -122,7 +146,12 @@ Parsing rules:
 - Deduplicate by the final qualified identifier, keeping the first occurrence.
 - Do not reject `/` inside a model ID. Pi splits only the first slash, and some
   upstream model IDs legitimately contain further slashes.
-- Do not infer static CCB thinking levels from Pi's `reasoning` boolean.
+- Models without `reasoning: true` expose no thinking selector.
+- Read `thinkingLevelMap` using Pi 0.84.4 semantics: `null` disables a level,
+  a string enables it, omitted standard levels use Pi defaults, and omitted
+  `xhigh`/`max` levels remain unsupported. Malformed mappings yield no levels.
+- Return only supported level names in Pi order, never the provider's mapping
+  values. CCB does not write or normalize the source catalog.
 
 Security rule: never copy arbitrary fields from `models.json`. In particular,
 `apiKey`, `baseUrl`, `headers`, command substitutions, and provider display
@@ -154,7 +183,7 @@ The capability record for Pi becomes:
     }
   ],
   "custom_model": false,
-  "static_thinking": false
+  "static_thinking": true
 }
 ```
 
@@ -175,7 +204,9 @@ dense native selector is preferable to a new modal or custom picker.
   option. Do not silently reset it to `inherit` when capabilities refresh.
 - Provider change away from Pi: retain the current existing behavior that
   clears model and thinking overlays to avoid cross-provider inheritance.
-- Thinking selector: remains disabled for Pi in this delivery.
+- Thinking selector: enabled for a catalog model with non-empty reasoning
+  levels. `inherit` clears the override. Selecting a new model retains a
+  supported level and clears an incompatible one, matching existing behavior.
 - Fallback/offline page data: mark Pi as model-shortcut capable with an empty
   catalog and custom entry disabled. The static HTML must not embed
   machine-local model names.
@@ -205,6 +236,15 @@ This single shared registration intentionally drives all existing contracts:
 - `provider_backends/pi/launcher.py` already appends `spec.startup_args`, so no
   Pi-launcher special case is needed.
 
+Thinking follows the existing Claude/Codex pattern in
+`lib/provider_thinking_shortcuts.py`: Pi registers its CLI-level superset
+(`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`), compiles to
+`--thinking`, detects conflicting explicit flags, and strips generated flags
+when rendering. `AgentSpec` and the launcher remain generic. The catalog
+restricts the UI to each model's capabilities; Pi performs final native
+model-specific validation. A structured `thinking` flag takes precedence over
+Pi's model-pattern thinking suffix according to Pi's CLI contract.
+
 The model string is treated as an opaque non-empty value by the shared compiler.
 The Pi dropdown emits only qualified values from the catalog. Manually authored
 TOML remains compatible and is ultimately validated by Pi at startup; Config UI
@@ -212,15 +252,36 @@ does not add an arbitrary model-entry path for Pi.
 
 ## Data And Persistence
 
-There is no new persisted field or migration. The only stored value is:
+There is no new persisted field or migration. Selection uses existing fields:
 
 ```toml
 [agents.agent_name]
 model = "provider/model-id"
+thinking = "high"
 ```
 
 The Pi provider prefix belongs inside this string. CCB must not split it into a
-new field, and must not persist the generated `--model` arguments.
+new field, and must not persist the generated `--model` or `--thinking` arguments.
+
+For a custom Astra model to expose exactly five levels, its Pi-native model
+entry needs `reasoning: true` and this metadata:
+
+```json
+"thinkingLevelMap": {
+  "off": null,
+  "minimal": null,
+  "low": "low",
+  "medium": "medium",
+  "high": "high",
+  "xhigh": "xhigh",
+  "max": "max"
+}
+```
+
+This is provider configuration supplied by its owner, not a new CCB setting or
+a Config UI write operation. Existing one-way inheritance copies it into a
+managed Pi home on normal launch. Refresh the Config UI service to rebuild its
+cached capabilities after changing the catalog.
 
 The value may contain `/`, `:`, dots, or hyphens because it is TOML string data
 and Pi owns model-pattern interpretation. CCB's existing TOML serializer handles
@@ -253,7 +314,7 @@ visible validation error, matching Codex, Claude, Gemini, and OpenCode.
   an empty list without failing the capability response;
 - payload serialization contains no API key, URL, header, or source path;
 - Pi advertises `model_shortcut = true`, `custom_model = false`,
-  `static_thinking = false`, and `model_source = "pi_models_json"`;
+  `static_thinking = true`, and `model_source = "pi_models_json"`;
 - the embedded fallback capability marks Pi writable but embeds no local models.
 
 ### Config compiler and rendering tests
@@ -307,24 +368,33 @@ the saved config. The launch test builds the Pi start command with a stub
 - Invalid/unavailable catalogs do not break Config UI or erase an existing
   configured model.
 - `/api/capabilities` exposes no Pi credentials, endpoints, headers, or paths.
-- Existing non-Pi model behavior and focused regression suites remain green.
+- Other providers retain their existing behavior; Codex cache precedence and
+  non-Astra levels remain covered by regression tests.
 
 ## Verification Status
 
 - Design discovery: complete.
 - Local Pi CLI contract: verified against version `0.84.4`.
 - Current upstream documentation: verified through Context7 and installed docs.
-- Implementation: complete in the shared model-shortcut compiler, Config UI
-  capability service, and browser model-selector state.
-- Catalog acceptance: the effective local catalog exposes the expected five
-  qualified IDs: `pay/gpt-5.6-sol`, `pay/gpt-5.6-terra`,
-  `pay/gpt-5.6-luna`, `pay/gpt-image-2`, and
-  `local/gemini-3.8-flash-high`.
-- Automated and shared-contract verification: `python3 -m pytest -q
-  test/test_config_ui.py test/test_v2_config_loader.py
+- Implementation: complete in the shared model/thinking shortcut compilers,
+  Config UI capability service, and existing browser selector.
+- Catalog acceptance: Codex fallback and the local Pi `pay/gpt-6-astra` entry
+  both expose `low`, `medium`, `high`, `xhigh`, `max`. Pi 0.84.4's native
+  `getSupportedThinkingLevels` and `clampThinkingLevel` confirm that the
+  explicit mapping preserves `max` rather than lowering it to `high`.
+- Automated and shared-contract verification on 2026-09-06:
+  `env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost
+  python3 -m pytest -q test/test_config_ui.py
+  test/test_provider_thinking_shortcuts.py test/test_v2_config_loader.py
   test/test_v2_runtime_launch.py test/test_mobile_gateway_service.py
   test/test_v3_config_loader.py test/test_provider_control_settings.py` passes
-  with 486 tests.
+  with 522 tests. Localhost bypass is limited to the test process because the
+  host proxy otherwise returns HTTP 503 for local test servers.
+- Browser verification: Playwright with installed Chrome, using a temporary
+  project and the real Config UI HTTP handlers, selected all five levels for
+  both providers, saved/reloaded `max`, checked the 390px mobile control and
+  Codex fallback after an API failure, and reported no JavaScript errors.
+  The temporary server was stopped after verification.
 - Static verification: `python3 -m py_compile` for all modified Python source
   and test files, plus `git diff --check`, passes.
 
@@ -337,9 +407,9 @@ the saved config. The launch test builds the Pi start command with a stub
 - The catalog proves local configuration, not provider authentication or remote
   endpoint availability. Pi remains the runtime authority and reports launch
   errors normally.
-- Pi supports thinking suffixes and `--thinking`, but mapping CCB's thinking
-  selector to Pi is intentionally deferred until its precedence and
-  round-trip behavior are designed separately.
+- V3 workflow policy and loop role profiles retain their existing
+  `low`/`medium`/`high` validation. This change targets static agent overlays
+  in Config UI and does not expand workflow-policy enums.
 - Headless Pi execution currently builds a job command without agent model
   policy. Propagating static model selection into that path requires a separate
   execution-contract change.

--- a/lib/cli/services/config_ui.py
+++ b/lib/cli/services/config_ui.py
@@ -55,6 +55,7 @@ _CAPABILITIES_CLI_MODELS_BUDGET_S = 0.1
 _CAPABILITIES_CLI_MODELS_RETRY_S = 0.5
 _PROFILE_NAME_PATTERN = re.compile(r'^[A-Za-z][A-Za-z0-9_.-]{0,63}$')
 _CONFIG_UI_RELATIVE_PATH = Path('assets/config_ui/index.html')
+_ASTRA_REASONING_LEVELS = ('low', 'medium', 'high', 'xhigh', 'max')
 
 
 @dataclass
@@ -567,7 +568,9 @@ def _codex_models(
             if not isinstance(item, dict) or item.get('visibility') != 'list':
                 continue
             model_id = str(item.get('slug') or '').strip()
-            if not model_id or not (model_id.startswith('gpt-5.6') or model_id == 'gpt-5.5'):
+            if not model_id or not (
+                model_id.startswith('gpt-5.6') or model_id in {'gpt-5.5', 'gpt-6-astra'}
+            ):
                 continue
             levels = []
             for level in item.get('supported_reasoning_levels') or []:
@@ -576,12 +579,17 @@ def _codex_models(
                 effort = str(level.get('effort') or '').strip()
                 if effort:
                     levels.append(effort)
+            default_level = str(item.get('default_reasoning_level') or '').strip() or None
+            if model_id == 'gpt-6-astra':
+                levels = [level for level in _ASTRA_REASONING_LEVELS if level in levels]
+                if default_level not in levels:
+                    default_level = None
             rows.append(
                 _model(
                     model_id,
                     str(item.get('display_name') or model_id),
                     reasoning_levels=levels,
-                    default_reasoning_level=str(item.get('default_reasoning_level') or '').strip() or None,
+                    default_reasoning_level=default_level,
                     context_window_max_tokens=(
                         int(item.get('context_window'))
                         if str(item.get('context_window') or '').isdigit()
@@ -592,6 +600,12 @@ def _codex_models(
         if rows:
             return rows, source
     return [
+        _model(
+            'gpt-6-astra',
+            'GPT-6 Astra',
+            reasoning_levels=list(_ASTRA_REASONING_LEVELS),
+            default_reasoning_level='low',
+        ),
         _model(
             'gpt-5.6-sol',
             'GPT-5.6 SOL',
@@ -680,8 +694,31 @@ def _pi_models(
             if qualified_id in seen:
                 continue
             seen.add(qualified_id)
-            rows.append(_model(qualified_id, qualified_id))
+            rows.append(
+                _model(
+                    qualified_id,
+                    qualified_id,
+                    reasoning_levels=_pi_model_reasoning_levels(item),
+                )
+            )
     return rows
+
+
+def _pi_model_reasoning_levels(model: dict[str, object]) -> list[str]:
+    if model.get('reasoning') is not True:
+        return []
+    mapping = model.get('thinkingLevelMap', {})
+    if not isinstance(mapping, dict):
+        return []
+    # Pi requires explicit mappings for extended levels; null disables a level.
+    return [
+        level
+        for level in provider_thinking_levels('pi')
+        if (
+            (level not in mapping and level not in {'xhigh', 'max'})
+            or isinstance(mapping.get(level), str)
+        )
+    ]
 
 
 def _codex_models_cache_paths(

--- a/lib/provider_thinking_shortcuts.py
+++ b/lib/provider_thinking_shortcuts.py
@@ -10,6 +10,7 @@ _PROVIDER_THINKING_LEVELS = {
     'deepseek': ('off', 'high', 'max'),
     # DSH validates these on session.selectModel rather than at process start.
     'dsh': ('off', 'high', 'max'),
+    'pi': ('off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'),
 }
 
 _PROVIDER_THINKING_RUNTIME_ENV = {
@@ -47,6 +48,8 @@ def provider_thinking_startup_args(provider: str, *, thinking: str | None) -> tu
         return ('-c', f'model_reasoning_effort="{value}"')
     if normalized_provider == 'claude':
         return ('--effort', value)
+    if normalized_provider == 'pi':
+        return ('--thinking', value)
     return ()
 
 
@@ -75,6 +78,11 @@ def startup_args_contain_thinking_flag(
 ) -> bool:
     normalized_provider = str(provider or '').strip().lower()
     args = tuple(str(item) for item in startup_args)
+    if normalized_provider == 'pi':
+        return any(
+            arg == '--thinking' or arg.startswith('--thinking=')
+            for arg in args
+        )
     if normalized_provider == 'claude':
         return any(
             arg == '--effort' or arg.startswith('--effort=')

--- a/test/test_config_ui.py
+++ b/test/test_config_ui.py
@@ -1566,7 +1566,7 @@ def test_config_ui_provider_capabilities_use_current_safe_model_sources(tmp_path
     ]
     assert providers['pi']['model_shortcut'] is True
     assert providers['pi']['custom_model'] is False
-    assert providers['pi']['static_thinking'] is False
+    assert providers['pi']['static_thinking'] is True
     assert providers['pi']['model_source'] == 'pi_models_json'
     serialized_pi = json.dumps(providers['pi'])
     assert 'secret-pay-key' not in serialized_pi
@@ -1579,7 +1579,7 @@ def test_config_ui_provider_capabilities_use_current_safe_model_sources(tmp_path
     assert all(
         provider['static_thinking'] is False
         for name, provider in providers.items()
-        if name not in {'codex', 'claude', 'deepseek', 'dsh'}
+        if name not in {'codex', 'claude', 'deepseek', 'dsh', 'pi'}
     )
 
 
@@ -1651,7 +1651,7 @@ def test_config_ui_pi_model_catalog_uses_source_home_before_home(tmp_path: Path)
     assert [model['id'] for model in pi['models']] == ['pay/gpt-5.6-terra']
 
 
-def test_config_ui_codex_fallback_keeps_current_56_family_and_55(tmp_path: Path) -> None:
+def test_config_ui_codex_fallback_includes_astra_and_keeps_56_family_and_55(tmp_path: Path) -> None:
     payload = config_ui_provider_capabilities(
         environ={'HOME': str(tmp_path), 'PATH': ''},
         codex_models_path=tmp_path / 'missing-models-cache.json',
@@ -1661,11 +1661,89 @@ def test_config_ui_codex_fallback_keeps_current_56_family_and_55(tmp_path: Path)
 
     assert codex['model_source'] == 'ccb_catalog_fallback'
     assert [model['id'] for model in codex['models']] == [
+        'gpt-6-astra',
         'gpt-5.6-sol',
         'gpt-5.6-terra',
         'gpt-5.6-luna',
         'gpt-5.5',
     ]
+    assert codex['models'][0]['reasoning_levels'] == ['low', 'medium', 'high', 'xhigh', 'max']
+    assert codex['models'][0]['default_reasoning_level'] == 'low'
+
+
+@pytest.mark.parametrize(
+    ('visibility', 'efforts', 'default_level', 'expected', 'expected_default'),
+    [
+        ('list', ['max', 'high', 'low', 'xhigh', 'medium', 'ultra', 'off', 'max'],
+         'max', ['low', 'medium', 'high', 'xhigh', 'max'], 'max'),
+        ('list', ['low', 'high'], 'ultra', ['low', 'high'], None),
+        ('hide', ['high'], 'high', None, None),
+    ],
+)
+def test_config_ui_codex_astra_respects_cache_visibility_and_capabilities(
+    tmp_path: Path,
+    visibility: str,
+    efforts: list[str],
+    default_level: str,
+    expected: list[str] | None,
+    expected_default: str | None,
+) -> None:
+    cache = tmp_path / 'models_cache.json'
+    cache.write_text(json.dumps({'models': [
+        {
+            'slug': 'gpt-6-astra',
+            'visibility': visibility,
+            'supported_reasoning_levels': [{'effort': level} for level in efforts],
+            'default_reasoning_level': default_level,
+            'context_window': 1000000,
+        },
+        {'slug': 'gpt-5.6-sol', 'visibility': 'list'},
+    ]}), encoding='utf-8')
+    models, source = config_ui_module._codex_models(
+        {}, project_root=None, explicit_path=cache,
+    )
+    assert source == 'codex_cache_explicit'
+    astra = next((model for model in models if model['id'] == 'gpt-6-astra'), None)
+    if expected is None:
+        assert astra is None
+    else:
+        assert astra is not None
+        assert astra['reasoning_levels'] == expected
+        assert astra['default_reasoning_level'] == expected_default
+        assert astra['context_window_max_tokens'] == 1000000
+
+
+@pytest.mark.parametrize(
+    ('metadata', 'expected'),
+    [
+        ({'reasoning': True, 'thinkingLevelMap': {
+            'max': 'max', 'xhigh': 'xhigh', 'high': 'high', 'medium': 'medium',
+            'low': 'low', 'off': None, 'minimal': None,
+        }}, ['low', 'medium', 'high', 'xhigh', 'max']),
+        ({'reasoning': True}, ['off', 'minimal', 'low', 'medium', 'high']),
+        ({'reasoning': True, 'thinkingLevelMap': {
+            'off': None, 'minimal': None, 'low': None, 'medium': None,
+            'high': 'provider-high', 'xhigh': None, 'max': 'provider-max',
+        }}, ['high', 'max']),
+        ({'reasoning': False, 'thinkingLevelMap': {'max': 'max'}}, []),
+        ({}, []),
+        ({'reasoning': True, 'thinkingLevelMap': []}, []),
+        ({'reasoning': True, 'thinkingLevelMap': {'xhigh': False, 'max': 100}},
+         ['off', 'minimal', 'low', 'medium', 'high']),
+    ],
+)
+def test_config_ui_pi_thinking_uses_native_model_mapping(
+    tmp_path: Path, metadata: dict[str, object], expected: list[str],
+) -> None:
+    catalog = tmp_path / 'models.json'
+    catalog.write_text(json.dumps({'providers': {'pay': {'models': [
+        {'id': 'gpt-6-astra', **metadata},
+    ]}}}), encoding='utf-8')
+    models = config_ui_module._pi_models(explicit_path=catalog, source_home=None)
+    assert models[0]['id'] == 'pay/gpt-6-astra'
+    assert models[0]['reasoning_levels'] == expected
+    assert 'provider-high' not in json.dumps(models)
+    assert 'provider-max' not in json.dumps(models)
 
 
 def test_config_ui_prefers_project_managed_codex_model_cache(tmp_path: Path) -> None:

--- a/test/test_provider_thinking_shortcuts.py
+++ b/test/test_provider_thinking_shortcuts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from provider_thinking_shortcuts import (
+    normalize_provider_thinking,
     provider_thinking_levels,
     provider_thinking_startup_args,
     startup_args_contain_thinking_flag,
@@ -27,3 +30,26 @@ def test_claude_effort_compiles_to_current_cli_contract() -> None:
         ['--effort', 'xhigh', '--permission-mode', 'manual'],
         thinking='xhigh',
     ) == ('--permission-mode', 'manual')
+
+
+@pytest.mark.parametrize('level', ['low', 'medium', 'high', 'xhigh', 'max'])
+def test_pi_thinking_compiles_and_round_trips(level: str) -> None:
+    assert provider_thinking_startup_args('pi', thinking=level) == ('--thinking', level)
+    assert strip_provider_thinking_startup_args(
+        'pi', ['--thinking', level, '--offline'], thinking=level,
+    ) == ('--offline',)
+
+
+@pytest.mark.parametrize('args', [['--thinking', 'high'], ['--thinking=max']])
+def test_pi_thinking_detects_explicit_flag(args: list[str]) -> None:
+    assert startup_args_contain_thinking_flag('pi', args)
+
+
+def test_pi_thinking_preserves_provider_specific_levels() -> None:
+    assert provider_thinking_levels('pi') == ('off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max')
+    with pytest.raises(ValueError, match='must be one of'):
+        normalize_provider_thinking('pi', 'ultra')
+    assert provider_thinking_startup_args('codex', thinking='ultra') == (
+        '-c', 'model_reasoning_effort="ultra"',
+    )
+    assert provider_thinking_startup_args('pi', thinking=None) == ()

--- a/test/test_v2_config_loader.py
+++ b/test/test_v2_config_loader.py
@@ -2626,6 +2626,45 @@ startup_args = ["--offline"]
     assert spec.startup_args == ('--model', 'pay/gpt-5.6-terra', '--offline')
 
 
+@pytest.mark.parametrize('provider', ['codex', 'pi'])
+@pytest.mark.parametrize('thinking', ['low', 'medium', 'high', 'xhigh', 'max'])
+def test_astra_thinking_round_trip(tmp_path: Path, provider: str, thinking: str) -> None:
+    model = 'gpt-6-astra' if provider == 'codex' else 'pay/gpt-6-astra'
+    config_path = tmp_path / '.ccb' / 'ccb.config'
+    _write(config_path, f'''cmd; agent1:{provider}
+
+[agents.agent1]
+model = "{model}"
+thinking = "{thinking}"
+startup_args = ["--offline"]
+''')
+    loaded = load_project_config(tmp_path).config
+    expected_args = (
+        ('-m', model, '-c', f'model_reasoning_effort="{thinking}"', '--offline')
+        if provider == 'codex'
+        else ('--model', model, '--thinking', thinking, '--offline')
+    )
+    assert loaded.agents['agent1'].startup_args == expected_args
+    rendered = render_project_config_text(loaded)
+    assert f'thinking = "{thinking}"' in rendered
+    assert 'startup_args = ["--offline"]' in rendered
+    _write(config_path, rendered)
+    assert load_project_config(tmp_path).config.agents['agent1'].startup_args == expected_args
+
+
+@pytest.mark.parametrize('args', ['["--thinking", "low"]', '["--thinking=low"]'])
+def test_pi_thinking_rejects_duplicate_startup_override(tmp_path: Path, args: str) -> None:
+    _write(tmp_path / '.ccb' / 'ccb.config', f'''cmd; agent1:pi
+
+[agents.agent1]
+model = "pay/gpt-6-astra"
+thinking = "max"
+startup_args = {args}
+''')
+    with pytest.raises(ConfigValidationError, match='thinking cannot be combined with startup_args'):
+        load_project_config(tmp_path)
+
+
 @pytest.mark.parametrize(
     ('provider', 'model_name', 'thinking'),
     [

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -89,6 +89,7 @@ def _spec(
     *,
     startup_args: tuple[str, ...] = (),
     model: str | None = None,
+    thinking: str | None = None,
     provider_command_template: str | None = None,
     restore_default: RestoreMode = RestoreMode.AUTO,
 ) -> AgentSpec:
@@ -104,6 +105,7 @@ def _spec(
         queue_policy=QueuePolicy.SERIAL_PER_AGENT,
         provider_command_template=provider_command_template,
         model=model,
+        thinking=thinking,
         startup_args=startup_args,
     )
 
@@ -2396,15 +2398,17 @@ def test_native_cli_launcher_builds_provider_state_payload(
         assert visible_parts == [default_executable, '--demo']
 
 
+@pytest.mark.parametrize('thinking', [None, 'low', 'medium', 'high', 'xhigh', 'max'])
 def test_pi_launcher_includes_qualified_agent_model_without_provider_flag(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    thinking: str | None,
 ) -> None:
     source_home = tmp_path / 'source-home'
     source_agent = source_home / '.pi' / 'agent'
     source_agent.mkdir(parents=True)
     (source_agent / 'models.json').write_text(
-        '{"providers":{"pay":{"models":[{"id":"gpt-5.6-terra"}]}}}\n',
+        '{"providers":{"pay":{"models":[{"id":"gpt-6-astra"}]}}}\n',
         encoding='utf-8',
     )
     monkeypatch.setenv('CCB_SOURCE_HOME', str(source_home))
@@ -2418,7 +2422,7 @@ def test_pi_launcher_includes_qualified_agent_model_without_provider_flag(
         auto_permission=False,
     )
     ctx = _context(project_root, command)
-    spec = _spec('pi1', provider='pi', model='pay/gpt-5.6-terra')
+    spec = _spec('pi1', provider='pi', model='pay/gpt-6-astra', thinking=thinking)
     plan = WorkspacePlanner().plan(spec, ctx.project)
     plan.workspace_path.mkdir(parents=True, exist_ok=True)
     runtime_dir = ctx.paths.agent_provider_runtime_dir('pi1', 'pi')
@@ -2436,8 +2440,13 @@ def test_pi_launcher_includes_qualified_agent_model_without_provider_flag(
 
     assert visible_parts.count('--model') == 1
     model_index = visible_parts.index('--model')
-    assert visible_parts[model_index + 1] == 'pay/gpt-5.6-terra'
+    assert visible_parts[model_index + 1] == 'pay/gpt-6-astra'
     assert '--provider' not in visible_parts
+    if thinking is None:
+        assert '--thinking' not in visible_parts
+    else:
+        assert visible_parts.count('--thinking') == 1
+        assert visible_parts[visible_parts.index('--thinking') + 1] == thinking
 
 
 def test_qoder_launcher_respects_explicit_config_and_permission_options(


### PR DESCRIPTION
## 问题与结果

Config UI 原先会过滤掉 Codex 的 `gpt-6-astra`，Pi 则只能选择模型，无法配置思考强度。本次为 Codex 接入 Astra，并让 Pi 使用本地模型能力启用强度选择，沿用现有 `model`、`thinking` 字段和共用参数编译流程。

## 改动

- Codex 缓存筛选放行 Astra，后端及前端兜底提供 `low → medium → high → xhigh → max`。有效缓存仍优先，缓存中限制的档位不会被扩展；其他 Codex 模型的档位保持原状。
- Pi 从 `reasoning`、`thinkingLevelMap` 读取有序档位，保留 `null` 禁用、扩展档位需显式声明的原生语义，仅返回档位名。
- Pi 的结构化 `thinking` 编译为 `--thinking <level>`，支持重复参数检测及 TOML 往返。复用现有校验、序列化、启动器和界面控件。
- 更新现有功能文档及配置契约，修改范围限于 Codex 和 Pi。

## 验证

- 522 项自动测试通过，覆盖 Config UI、快捷参数、V2 配置与启动、V3 回归、provider settings 和移动网关。
- Playwright 配合本机 Chrome：两种 provider 均逐档选择成功，`max` 保存及重新加载正确；390px 移动视口、接口失败时的 Codex 兜底通过，无 JavaScript 错误。
- 本机 Pi 0.84.4 原生档位函数验证显式映射后的 Astra `max` 不被降档。
- `py_compile`、`git diff --check` 通过；本地预览包已安装，安装包源码一致性、依赖和 Config UI 接口验证通过，用户功能验收通过。

## 使用前提与范围

- Pi 自定义 Astra 条目需包含 `reasoning: true` 及五档 `thinkingLevelMap`。映射示例见 `docs/features/pi-model-selection.md`；CCB 不自动修改用户 `models.json`。
- Codex 有效旧缓存若未列出 Astra，仍以该缓存为准；更新目录后需重新启动 Config UI 服务以刷新能力缓存。
- 保留 V3 工作流和 loop role profiles 的三档策略；不扩展 Pi 旧版 headless 执行路径。
- 未进行自动化真实模型 API 请求。本机模型配置、安装目录和构建产物均不包含在提交中。
