### PR TITLE
fix: rehydrate Claude proxy auth on pane-foreign recovery

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/service.py
+++ b/lib/provider_backends/claude/launcher_runtime/service.py
@@ -264,7 +264,70 @@ def _persistable_start_cmd(start_cmd: str, *, settings_path: Path) -> str:
     return command.strip(' ;')
 
 
-__all__ = ['build_runtime_launcher', 'build_session_payload', 'build_start_cmd', 'prepare_runtime', 'resolve_run_cwd']
+def rehydrate_claude_persisted_start_cmd(
+    start_cmd: str,
+    *,
+    credential_env: dict[str, str] | None = None,
+) -> str:
+    """Restore sensitive Claude API exports stripped by ``_persistable_start_cmd``.
+
+    Pane recovery (including ``pane-foreign`` refresh → ``ensure_pane``) respawns
+    from the persisted ``start_cmd``. That command intentionally omits
+    ``ANTHROPIC_AUTH_TOKEN`` / ``ANTHROPIC_API_KEY`` so credentials are not
+    written to session files, but it keeps route keys such as
+    ``ANTHROPIC_BASE_URL``. Without rehydration, recovery can relaunch against a
+    proxy URL with no auth and land on Claude's login prompt, while an explicit
+    ``ccb restart`` rebuilds the full command from current config.
+    """
+    command = str(start_cmd or '').strip()
+    missing = {
+        key: value
+        for key, value in dict(credential_env or {}).items()
+        if key in _SENSITIVE_PERSISTED_ENV
+        and str(value or '').strip()
+        and f'{key}=' not in command
+    }
+    if not missing:
+        return command
+    export = 'export ' + ' '.join(
+        f'{key}={shlex.quote(str(value))}' for key, value in sorted(missing.items())
+    )
+    if not command:
+        return export
+    return f'{export}; {command}'
+
+
+def claude_respawn_credential_env(runtime_dir: Path | None) -> dict[str, str]:
+    """Load Claude API credentials from the materialized provider profile."""
+    if runtime_dir is None:
+        return {}
+    try:
+        from provider_profiles import load_resolved_provider_profile
+    except Exception:
+        return {}
+    try:
+        profile = load_resolved_provider_profile(Path(runtime_dir))
+    except Exception:
+        return {}
+    if profile is None:
+        return {}
+    env = dict(getattr(profile, 'env', {}) or {})
+    return {
+        key: str(env.get(key) or '').strip()
+        for key in sorted(_SENSITIVE_PERSISTED_ENV)
+        if str(env.get(key) or '').strip()
+    }
+
+
+__all__ = [
+    'build_runtime_launcher',
+    'build_session_payload',
+    'build_start_cmd',
+    'claude_respawn_credential_env',
+    'prepare_runtime',
+    'rehydrate_claude_persisted_start_cmd',
+    'resolve_run_cwd',
+]
 
 
 def _append_unique_flag(parts: list[str], flag: str, startup_args: tuple[str, ...]) -> None:

--- a/lib/provider_backends/claude/session_runtime/model.py
+++ b/lib/provider_backends/claude/session_runtime/model.py
@@ -9,6 +9,10 @@ from provider_runtime.session_payload import pane_id_from_session, pane_ref_from
 from terminal_runtime import get_backend_for_session
 
 from ..home_layout import claude_layout_from_session_data
+from ..launcher_runtime.service import (
+    claude_respawn_credential_env,
+    rehydrate_claude_persisted_start_cmd,
+)
 from .normalization import normalize_session_data, strip_claude_continue_start_cmd
 from .lifecycle import attach_pane_log, ensure_pane, update_claude_binding, write_back
 
@@ -68,7 +72,11 @@ class ClaudeProjectSession:
 
     @property
     def start_cmd(self) -> str:
-        return str(self.data.get("start_cmd") or "").strip()
+        raw = str(self.data.get("start_cmd") or self.data.get("claude_start_cmd") or "").strip()
+        return rehydrate_claude_persisted_start_cmd(
+            raw,
+            credential_env=claude_respawn_credential_env(self.runtime_dir),
+        )
 
     def prepare_crash_recovery(self, reason: str) -> tuple[bool, str] | None:
         if reason != 'provider_session_missing':

--- a/test/test_claude_launcher_env.py
+++ b/test/test_claude_launcher_env.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from provider_backends.claude.launcher_runtime.env import build_claude_env_prefix, claude_user_base_url, write_claude_settings_overlay
+from provider_backends.claude.launcher_runtime.service import (
+    _persistable_start_cmd,
+    claude_respawn_credential_env,
+    rehydrate_claude_persisted_start_cmd,
+)
 from provider_profiles.models import ResolvedProviderProfile
 
 
@@ -90,6 +96,58 @@ def test_build_claude_env_prefix_unsets_competing_ambient_aliases_for_explicit_c
     assert 'ANTHROPIC_BASE_URL=https://explicit.example.test' in result
     assert 'ambient-token' not in result
     assert 'ambient.example.test' not in result
+
+
+def test_persistable_start_cmd_strips_auth_but_keeps_proxy_base_url(tmp_path: Path) -> None:
+    settings_path = tmp_path / 'claude-settings.json'
+    start_cmd = (
+        'export ANTHROPIC_AUTH_TOKEN=proxy-token '
+        'ANTHROPIC_BASE_URL=https://proxy.example.test '
+        f'HOME={tmp_path / "home"}; claude --continue'
+    )
+
+    persisted = _persistable_start_cmd(start_cmd, settings_path=settings_path)
+
+    assert 'ANTHROPIC_AUTH_TOKEN=' not in persisted
+    assert 'ANTHROPIC_BASE_URL=https://proxy.example.test' in persisted
+    assert 'claude --continue' in persisted
+
+
+def test_rehydrate_claude_persisted_start_cmd_restores_proxy_auth_token() -> None:
+    persisted = (
+        'export ANTHROPIC_BASE_URL=https://proxy.example.test HOME=/tmp/home; '
+        'claude --continue'
+    )
+
+    restored = rehydrate_claude_persisted_start_cmd(
+        persisted,
+        credential_env={'ANTHROPIC_AUTH_TOKEN': 'proxy-token'},
+    )
+
+    assert restored.startswith('export ANTHROPIC_AUTH_TOKEN=proxy-token;')
+    assert 'ANTHROPIC_BASE_URL=https://proxy.example.test' in restored
+    assert restored.endswith('claude --continue')
+
+
+def test_claude_respawn_credential_env_reads_provider_profile(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / 'runtime'
+    runtime_dir.mkdir()
+    profile = ResolvedProviderProfile(
+        provider='claude',
+        agent_name='advisor',
+        env={
+            'ANTHROPIC_AUTH_TOKEN': 'proxy-token',
+            'ANTHROPIC_BASE_URL': 'https://proxy.example.test',
+        },
+    )
+    (runtime_dir / 'provider-profile.json').write_text(
+        json.dumps(profile.to_record()),
+        encoding='utf-8',
+    )
+
+    assert claude_respawn_credential_env(runtime_dir) == {
+        'ANTHROPIC_AUTH_TOKEN': 'proxy-token',
+    }
 
 
 def test_write_claude_settings_overlay_returns_none_without_agent_settings(tmp_path) -> None:

--- a/test/test_claude_session_fields.py
+++ b/test/test_claude_session_fields.py
@@ -12,6 +12,50 @@ from provider_backends.claude.session import ClaudeProjectSession
 from project.identity import normalize_work_dir
 
 
+def test_claude_session_start_cmd_rehydrates_proxy_auth_for_pane_recovery(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / 'runtime'
+    runtime_dir.mkdir()
+    (runtime_dir / 'provider-profile.json').write_text(
+        json.dumps(
+            {
+                'provider': 'claude',
+                'agent_name': 'advisor',
+                'mode': 'inherit',
+                'env': {
+                    'ANTHROPIC_AUTH_TOKEN': 'proxy-token',
+                    'ANTHROPIC_BASE_URL': 'https://proxy.example.test',
+                },
+                'inherit_api': True,
+                'inherit_auth': True,
+                'inherit_config': True,
+                'inherit_skills': True,
+                'inherit_commands': True,
+                'inherit_memory': True,
+            }
+        ),
+        encoding='utf-8',
+    )
+    session = ClaudeProjectSession(
+        session_file=tmp_path / '.claude-session',
+        data={
+            'runtime_dir': str(runtime_dir),
+            'work_dir': str(tmp_path),
+            # Persisted recovery command keeps the proxy URL but drops auth.
+            'start_cmd': (
+                'export ANTHROPIC_BASE_URL=https://proxy.example.test; '
+                'claude --continue'
+            ),
+        },
+    )
+
+    start_cmd = session.start_cmd
+
+    assert 'ANTHROPIC_AUTH_TOKEN=proxy-token' in start_cmd
+    assert 'ANTHROPIC_BASE_URL=https://proxy.example.test' in start_cmd
+    # Disk payload stays redacted; only the respawn view is rehydrated.
+    assert 'ANTHROPIC_AUTH_TOKEN=' not in session.data['start_cmd']
+
+
 def test_claude_missing_session_recovery_drops_only_managed_continue_binding(tmp_path: Path) -> None:
     session_file = tmp_path / '.claude-session'
     session = ClaudeProjectSession(


### PR DESCRIPTION
## Summary
- Claude session files persist a redacted `start_cmd` that keeps `ANTHROPIC_BASE_URL` but drops `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`.
- `pane-foreign` recovery often respawns via `ensure_pane` using that redacted command, so proxy URL survives while auth is missing and Claude shows `Not logged in`.
- Rehydrate sensitive credentials from the materialized `provider-profile.json` when reading `start_cmd` for respawn; keep the on-disk session command redacted.
- Explicit `ccb restart` already rebuilt from current config; this aligns automatic recovery with that behavior.

Fixes #327

## Test plan
- [x] `python3 -m pytest test/test_claude_launcher_env.py test/test_claude_session_fields.py test/test_v2_provider_restore_launchers.py` → 47 passed
- [ ] Optional manual: configure Claude with proxy `ANTHROPIC_BASE_URL` + auth token, trigger `pane-foreign` recovery, confirm recovered process retains auth and does not require `/login`