### PR TITLE
fix: treat codex fork as continuation in start_cmd rewrite

### DIFF
--- a/lib/provider_backends/codex/start_cmd_runtime/rewriting.py
+++ b/lib/provider_backends/codex/start_cmd_runtime/rewriting.py
@@ -5,6 +5,11 @@ import re
 
 from .parsing import find_codex_token_index
 
+# `build_resume_start_cmd` means "make this command resume <session_id>".
+# Both `resume` and `fork` are continuation subcommands; keeping an existing
+# `fork <A>` and appending `resume <B>` produces an unparseable CLI.
+_CONTINUATION_SUBCOMMANDS = frozenset({'resume', 'fork'})
+
 
 def build_resume_start_cmd(command: object, session_id: object) -> str:
     normalized_session_id = str(session_id or '').strip()
@@ -56,12 +61,8 @@ def strip_resume_from_codex_segment(segment: str) -> str | None:
     codex_index = find_codex_token_index(tokens)
     if codex_index is None:
         return None
-    resume_index = None
-    for index in range(codex_index + 1, len(tokens)):
-        if tokens[index] == 'resume':
-            resume_index = index
-            break
-    base_tokens = tokens[:resume_index] if resume_index is not None else list(tokens)
+    continuation_index = _continuation_subcommand_index(tokens, codex_index)
+    base_tokens = tokens[:continuation_index] if continuation_index is not None else list(tokens)
     if not base_tokens:
         return None
     return ' '.join(shlex.quote(str(token)) for token in base_tokens)
@@ -77,14 +78,17 @@ def rewrite_codex_segment(segment: str, session_id: str) -> str | None:
     codex_index = find_codex_token_index(tokens)
     if codex_index is None:
         return None
-    resume_index = None
-    for index in range(codex_index + 1, len(tokens)):
-        if tokens[index] == 'resume':
-            resume_index = index
-            break
-    base_tokens = tokens[:resume_index] if resume_index is not None else list(tokens)
+    continuation_index = _continuation_subcommand_index(tokens, codex_index)
+    base_tokens = tokens[:continuation_index] if continuation_index is not None else list(tokens)
     base_tokens.extend(['resume', session_id])
     return ' '.join(shlex.quote(str(token)) for token in base_tokens)
+
+
+def _continuation_subcommand_index(tokens: list[str], codex_index: int) -> int | None:
+    for index in range(codex_index + 1, len(tokens)):
+        if tokens[index] in _CONTINUATION_SUBCOMMANDS:
+            return index
+    return None
 
 
 _MANAGED_RESUME_ASSIGNMENT_RE = re.compile(

--- a/test/test_codex_start_cmd_parsing.py
+++ b/test/test_codex_start_cmd_parsing.py
@@ -4,7 +4,12 @@ from provider_backends.codex.start_cmd_runtime.parsing import (
     extract_resume_session_id,
     looks_like_bare_resume_cmd,
 )
-from provider_backends.codex.start_cmd_runtime.rewriting import strip_resume_start_cmd
+from provider_backends.codex.start_cmd_runtime.rewriting import (
+    build_resume_start_cmd,
+    rewrite_codex_segment,
+    strip_resume_from_codex_segment,
+    strip_resume_start_cmd,
+)
 
 
 def test_extract_resume_session_id_prefers_regex_match() -> None:
@@ -50,3 +55,49 @@ def test_strip_resume_start_cmd_removes_resume_suffix_from_shell_wrapped_command
         'export CODEX_HOME=/tmp/home CODEX_SESSION_ROOT=/tmp/home/sessions; '
         'codex -m gpt-5.4'
     )
+
+
+def test_rewrite_codex_segment_replaces_fork_continuation_with_resume() -> None:
+    rewritten = rewrite_codex_segment(
+        'codex fork 00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002',
+    )
+
+    assert rewritten == 'codex resume 00000000-0000-0000-0000-000000000002'
+
+
+def test_rewrite_codex_segment_swaps_resume_id_without_keeping_old_continuation() -> None:
+    rewritten = rewrite_codex_segment(
+        'codex -c disable_paste_burst=true resume old-session',
+        'new-session',
+    )
+
+    assert rewritten == 'codex -c disable_paste_burst=true resume new-session'
+
+
+def test_rewrite_codex_segment_appends_resume_when_no_continuation_present() -> None:
+    rewritten = rewrite_codex_segment('codex -m gpt-5.4', 'sess-123')
+
+    assert rewritten == 'codex -m gpt-5.4 resume sess-123'
+
+
+def test_strip_resume_from_codex_segment_removes_fork_continuation() -> None:
+    stripped = strip_resume_from_codex_segment(
+        'codex fork 00000000-0000-0000-0000-000000000001'
+    )
+
+    assert stripped == 'codex'
+
+
+def test_build_resume_start_cmd_managed_remote_path_untouched_by_fork_fix() -> None:
+    command = (
+        "export CCB_CODEX_MANAGED_REMOTE=1 CCB_CODEX_RESUME_ID='old-id'; "
+        'codex --remote unix:///tmp/app-server.sock'
+    )
+
+    rewritten = build_resume_start_cmd(command, 'new-id')
+
+    assert 'CCB_CODEX_RESUME_ID=new-id' in rewritten
+    assert 'CCB_CODEX_MANAGED_REMOTE=1' in rewritten
+    assert 'fork' not in rewritten
+    assert 'resume new-id' not in rewritten


### PR DESCRIPTION
## Summary
- `rewrite_codex_segment` / `strip_resume_from_codex_segment` only recognized `resume`, so a stored `codex fork <A>` became `codex fork <A> resume <B>`.
- That unparseable command exits with status 2 and auto-recovery keeps relaunching the same bad command.
- Treat `fork` as a continuation subcommand boundary and replace it with `resume <session_id>` (managed-remote rewrite path unchanged).

Fixes #338

## Test plan
- [x] `python3 -m pytest test/test_codex_start_cmd_parsing.py` → 12 passed
- [x] Local repro of the issue case now yields `codex resume <B>` instead of `codex fork <A> resume <B>`