### PR TITLE
fix: skip transcript preamble when probing Claude sidechain

### DIFF
--- a/lib/provider_backends/claude/comm_runtime/session_selection_runtime/membership.py
+++ b/lib/provider_backends/claude/comm_runtime/session_selection_runtime/membership.py
@@ -8,6 +8,22 @@ from ...registry_support.pathing import (
     project_key_for_path,
 )
 
+# Transcript preambles can push the first `isSidechain` far past a small
+# fixed line window. Skip these record types so the probe budget is spent on
+# entries that can actually carry membership.
+_SIDECHAIN_PROBE_SKIP_TYPES = frozenset(
+    {
+        'file-history-snapshot',
+        'ai-title',
+        'agent-name',
+        'mode',
+        'permission-mode',
+        'summary',
+    }
+)
+_SIDECHAIN_PROBE_CANDIDATE_LIMIT = 40
+_SIDECHAIN_PROBE_ABSOLUTE_LINE_LIMIT = 2000
+
 
 def session_belongs_to_current_project(reader, session_path: Path) -> bool:
     candidate = _resolved_existing_path(session_path)
@@ -27,7 +43,12 @@ def project_dir(reader) -> Path:
 
 
 def session_is_sidechain(session_path: Path) -> bool | None:
-    entry = _first_json_entry_with_key(session_path, key='isSidechain', line_limit=20)
+    entry = _first_json_entry_with_key(
+        session_path,
+        key='isSidechain',
+        candidate_limit=_SIDECHAIN_PROBE_CANDIDATE_LIMIT,
+        absolute_line_limit=_SIDECHAIN_PROBE_ABSOLUTE_LINE_LIMIT,
+    )
     if entry is None:
         return None
     return bool(entry.get('isSidechain'))
@@ -75,14 +96,28 @@ def _candidate_parent_allowed(candidate_parent: Path, *, allowed_dirs: list[Path
     return any(candidate_parent == allowed_dir or allowed_dir in candidate_parent.parents for allowed_dir in allowed_dirs)
 
 
-def _first_json_entry_with_key(session_path: Path, *, key: str, line_limit: int) -> dict | None:
+def _first_json_entry_with_key(
+    session_path: Path,
+    *,
+    key: str,
+    candidate_limit: int,
+    absolute_line_limit: int,
+) -> dict | None:
     try:
         with session_path.open('r', encoding='utf-8', errors='replace') as handle:
-            for _ in range(line_limit):
+            candidates_seen = 0
+            for _ in range(max(0, int(absolute_line_limit))):
                 entry = _json_line_entry(handle.readline())
-                if entry is None or key not in entry:
+                if entry is None:
                     continue
-                return entry
+                entry_type = str(entry.get('type') or '').strip()
+                if entry_type in _SIDECHAIN_PROBE_SKIP_TYPES:
+                    continue
+                candidates_seen += 1
+                if key in entry:
+                    return entry
+                if candidates_seen >= max(1, int(candidate_limit)):
+                    break
     except OSError:
         return None
     return None

--- a/test/test_claude_session_selection.py
+++ b/test/test_claude_session_selection.py
@@ -102,6 +102,41 @@ def test_scan_latest_session_reads_sidechain_flag_after_summary_prelude(tmp_path
     assert reader._scan_latest_session() == session
 
 
+def test_session_is_sidechain_skips_file_history_snapshot_preamble(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / 'claude-root'
+    work_dir = tmp_path / 'project-a'
+    work_dir.mkdir()
+    monkeypatch.setenv('PWD', str(work_dir))
+
+    live = root / _project_key(work_dir) / 'live.jsonl'
+    stale = root / _project_key(work_dir) / 'stale.jsonl'
+    live.parent.mkdir(parents=True, exist_ok=True)
+    preamble = '\n'.join(
+        [
+            '{"type":"ai-title","title":"demo"}',
+            '{"type":"agent-name","name":"claude"}',
+            '{"type":"mode","mode":"default"}',
+            '{"type":"permission-mode","mode":"default"}',
+            *[
+                f'{{"type":"file-history-snapshot","messageId":"snap-{index}"}}'
+                for index in range(30)
+            ],
+            '{"type":"user","isSidechain":false,"message":{"role":"user","content":"live"}}',
+        ]
+    ) + '\n'
+    live.write_text(preamble, encoding='utf-8')
+    stale.write_text(
+        '{"type":"user","isSidechain":false,"message":{"role":"user","content":"stale"}}\n',
+        encoding='utf-8',
+    )
+    os.utime(live, (live.stat().st_atime, live.stat().st_mtime + 20))
+
+    reader = ClaudeLogReader(root=root, work_dir=work_dir, use_sessions_index=False)
+
+    assert reader._session_is_sidechain(live) is False
+    assert reader._scan_latest_session() == live
+
+
 def test_latest_session_ignores_env_pwd_project_namespace_for_workspace_reader(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- `session_is_sidechain()` previously scanned only the first 20 transcript lines for `isSidechain`.
- Live Claude sessions can start with many preamble records (`file-history-snapshot`, `ai-title`, `mode`, …), so the probe returned `None` and CCB selected a stale eligible session instead.
- Skip known preamble record types when probing and keep an absolute line safety window so membership comes from real message entries.

Fixes #282

## Test plan
- [x] `python3 -m pytest test/test_claude_session_selection.py` → 7 passed
- [x] Regression covers 30+ `file-history-snapshot` lines before the first `isSidechain=false` user entry