### PR TITLE
fix: resolve default Keychain for managed Claude HOME

### DIFF
--- a/docs/claude-session-isolation-contract.md
+++ b/docs/claude-session-isolation-contract.md
@@ -261,11 +261,15 @@ When `ccb` starts a managed Claude agent:
   different value already held by the agent-derived service because the
   managed Claude process may have refreshed its private credential after the
   last source projection
-- managed login-auth projection must not copy
+- managed login-auth projection must not copy the user's
   `~/Library/Preferences/com.apple.security.plist` or link the managed
   `Library/Keychains` path to the user's Keychains; startup must remove a
-  recognized legacy managed link and legacy copied preference without
-  traversing the user's Keychain
+  recognized legacy managed link without traversing the user's Keychain
+- managed login-auth projection may write a CCB-owned
+  `Library/Preferences/com.apple.security.plist` that points `DefaultKeychain`
+  at the user's login keychain by absolute path so Claude can resolve a default
+  Keychain from the private `HOME` without restoring the broad Keychains
+  symlink
 - managed login-auth projection may also synchronize older or alternate Claude
   Code credential cache artifacts such as `.config/claude-code/auth.json` when
   they exist in the source home

--- a/docs/provider-auth-inheritance-contract.md
+++ b/docs/provider-auth-inheritance-contract.md
@@ -167,9 +167,12 @@ representation on macOS. CCB may:
 
 Managed Claude must set `CLAUDE_CONFIG_DIR` and
 `CLAUDE_SECURESTORAGE_CONFIG_DIR` to its private `.claude` directory and disable
-both interactive login and logout commands. It must never copy
+both interactive login and logout commands. It must never copy the user's
 `com.apple.security.plist`, link `Library/Keychains`, or add/delete the user's
-ordinary Claude Keychain services.
+ordinary Claude Keychain services. It may write a CCB-owned
+`com.apple.security.plist` that points `DefaultKeychain` at the user's login
+keychain by absolute path so the managed `HOME` can resolve a default Keychain
+without restoring the broad Keychains symlink.
 
 Gemini, Cursor, and Droid may read known external keyring entries only to
 materialize provider-supported files inside their private managed homes. Their

--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 from pathlib import Path
+import plistlib
 import shutil
 import stat
 import subprocess
@@ -699,8 +700,11 @@ def _materialize_auth(source_home: Path, target_layout: ClaudeHomeLayout, *, pro
     )
 
 
+_MACOS_LOGIN_KEYCHAIN_GUID = '{87191ca3-0fc9-11d4-849a-000502b52122}'
+_MACOS_LOGIN_KEYCHAIN_SUBSERVICE_TYPE = 6
+
+
 def _materialize_macos_keychain_preferences(source_home: Path, target_layout: ClaudeHomeLayout, *, profile) -> None:
-    del source_home, profile
     target = target_layout.home_root / 'Library' / 'Preferences' / 'com.apple.security.plist'
     target_keychains = target_layout.home_root / 'Library' / 'Keychains'
     # Older CCB releases linked this path back to the user's real Keychains
@@ -708,9 +712,56 @@ def _materialize_macos_keychain_preferences(source_home: Path, target_layout: Cl
     # external login authority.  Credential inheritance is now copy-only, so
     # detach any legacy link before doing anything else.
     _remove_keychains_link(target_keychains)
-    # A copied preference file can itself point Security.framework back to the
-    # user's global keychain database, so remove legacy copies as well.
-    _remove_file(target)
+    if platform.system() != 'Darwin' or not _inherits_external_auth(profile):
+        # Never keep a copied/legacy preference when auth is not inherited.
+        _remove_file(target)
+        return
+    login_keychain = _resolve_macos_login_keychain_db_name(source_home)
+    if login_keychain is None:
+        _remove_file(target)
+        return
+    # Write a CCB-owned preference (not a copy of the user's plist) so the
+    # managed HOME can resolve a default Keychain without restoring the broad
+    # Library/Keychains symlink forbidden by the isolation contract.
+    _write_managed_default_keychain_preference(target, login_keychain)
+
+
+def _resolve_macos_login_keychain_db_name(source_home: Path) -> Path | None:
+    keychains = Path(source_home).expanduser() / 'Library' / 'Keychains'
+    for name in ('login.keychain-db', 'login.keychain'):
+        if (keychains / name).exists():
+            # Security.framework preference DbName historically uses the
+            # login.keychain basename even when the on-disk file is
+            # login.keychain-db.
+            return keychains / 'login.keychain'
+    return None
+
+
+def _write_managed_default_keychain_preference(target: Path, login_keychain: Path) -> None:
+    entry = {
+        'DbName': str(login_keychain),
+        'GUID': _MACOS_LOGIN_KEYCHAIN_GUID,
+        'SubserviceType': _MACOS_LOGIN_KEYCHAIN_SUBSERVICE_TYPE,
+    }
+    payload = {
+        'DefaultKeychain': [dict(entry)],
+        'DLDBSearchList': [dict(entry)],
+    }
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f'.{target.name}.tmp-{os.getpid()}')
+    try:
+        tmp.write_bytes(plistlib.dumps(payload, fmt=plistlib.FMT_XML))
+        if hasattr(os, 'replace'):
+            os.replace(tmp, target)
+        else:  # pragma: no cover
+            tmp.replace(target)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
 
 
 def _remove_keychains_link(path: Path) -> None:

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -3453,26 +3453,41 @@ def test_materialize_claude_home_config_private_keychain_inspection_error_fails_
     assert not any(call[1] == 'add-generic-password' for call in calls)
 
 
-def test_materialize_claude_home_config_does_not_project_macos_keychain_preferences(
+def test_materialize_claude_home_config_writes_ccb_owned_default_keychain_preference(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    import plistlib
+
     source_home = tmp_path / 'system-home'
     target_home = tmp_path / 'managed-home'
     source_plist = source_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    source_keychains = source_home / 'Library' / 'Keychains'
     source_plist.parent.mkdir(parents=True, exist_ok=True)
+    source_keychains.mkdir(parents=True, exist_ok=True)
+    # Distinct user preference content — managed home must not copy this file.
     source_plist.write_text(
         '<plist><dict><key>DefaultKeychain</key><array/></dict></plist>\n',
         encoding='utf-8',
     )
+    (source_keychains / 'login.keychain-db').write_bytes(b'fake-keychain')
 
     monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Darwin')
 
     materialize_claude_home_config(target_home, source_home=source_home)
 
     target_plist = target_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
-    assert not target_plist.exists()
-    assert source_plist.is_file()
+    assert target_plist.is_file()
+    payload = plistlib.loads(target_plist.read_bytes())
+    expected_db = str(source_keychains / 'login.keychain')
+    assert payload['DefaultKeychain'][0]['DbName'] == expected_db
+    assert payload['DLDBSearchList'][0]['DbName'] == expected_db
+    # Still must not copy the user's preference bytes.
+    assert target_plist.read_bytes() != source_plist.read_bytes()
+    # Still must not restore the broad Keychains symlink.
+    target_keychains = target_home / 'Library' / 'Keychains'
+    assert not target_keychains.exists()
+    assert not target_keychains.is_symlink()
 
 
 def test_materialize_claude_home_config_never_links_macos_keychains_when_preferences_absent(
@@ -3491,6 +3506,9 @@ def test_materialize_claude_home_config_never_links_macos_keychains_when_prefere
     target_keychains = target_home / 'Library' / 'Keychains'
     assert not target_keychains.exists()
     assert not target_keychains.is_symlink()
+    # Without a login keychain file, do not invent a preference.
+    target_plist = target_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    assert not target_plist.exists()
 
 
 def test_materialize_claude_home_config_detaches_legacy_macos_keychains_link(


### PR DESCRIPTION
## Summary
- Managed Claude private `HOME` previously deleted `com.apple.security.plist` and detached `Library/Keychains`, so `security default-keychain -d user` failed inside the managed environment.
- Write a **CCB-owned** preference (not a copy of the user's plist) that points `DefaultKeychain` / `DLDBSearchList` at the user's login keychain by absolute path.
- Keep the isolation contract: never restore the broad `Library/Keychains` symlink; remove the preference when auth inheritance is disabled.

Fixes #324

## Test plan
- [x] Keychain-related `test/test_provider_profiles.py` cases → 8 passed
- [x] Live macOS probe: after materializing preferences into a managed HOME, `HOME=<managed> security default-keychain -d user` resolves the login keychain and no `Library/Keychains` link is created
- [ ] Optional: start a managed Claude agent on macOS and confirm OAuth refresh / no “default keychain could not be found” dialog